### PR TITLE
Refactor header navigation to design tokens

### DIFF
--- a/src/lib/components/menu/DesktopNav.svelte
+++ b/src/lib/components/menu/DesktopNav.svelte
@@ -46,23 +46,23 @@
 		display: none;
 	}
 
-	.nav-list {
-		display: flex;
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		gap: var(--spacing-4);
-	}
+        .nav-list {
+                display: flex;
+                list-style: none;
+                padding: 0;
+                margin: 0;
+                gap: var(--spacing-4);
+        }
 
-	@media (min-width: 1024px) {
-		.desktop-nav {
-			display: block;
-		}
+        @media (min-width: 56rem) {
+                .desktop-nav {
+                        display: block;
+                }
 
-		.nav-list {
-			gap: var(--spacing-6); /* Wider spacing on larger screens */
-		}
-	}
+                .nav-list {
+                        gap: var(--spacing-6); /* Wider spacing on larger screens */
+                }
+        }
 
 	/* Navigation item styles */
 	:global(.nav-item) {
@@ -73,10 +73,10 @@
 	/* Focus and accessibility */
 	:global(.nav-link:focus-visible),
 	:global(.dropdown-item:focus-visible) {
-		outline: 2px solid var(--color-primary);
-		outline-offset: 2px;
-		border-radius: var(--border-radius-sm);
-	}
+                outline: var(--border-width-medium) solid var(--color-primary);
+                outline-offset: var(--spacing-1);
+                border-radius: var(--border-radius-sm);
+        }
 
 	/* Touch device optimizations */
 	@media (hover: none) {

--- a/src/lib/components/menu/DropdownMenu.svelte
+++ b/src/lib/components/menu/DropdownMenu.svelte
@@ -41,34 +41,33 @@
 </div>
 
 <style>
-	.dropdown-menu {
-		position: absolute;
-		top: calc(100% + 12px);
-		left: 0;
-		z-index: 1000;
-		min-width: 280px;
-		width: max-content;
-		max-width: 400px;
-		background: rgba(255, 255, 255, 0.95);
-		backdrop-filter: blur(20px) saturate(180%);
-		-webkit-backdrop-filter: blur(20px) saturate(180%);
-		border: 1px solid rgba(255, 255, 255, 0.4);
-		border-radius: var(--border-radius-lg);
-		box-shadow:
-			0 20px 60px 0 rgba(31, 38, 135, 0.15),
-			0 8px 32px 0 rgba(31, 38, 135, 0.1),
-			inset 0 1px 0 rgba(255, 255, 255, 0.6),
-			inset 0 -1px 0 rgba(255, 255, 255, 0.2);
-		padding: var(--spacing-3);
-		opacity: 0;
-		visibility: hidden;
-		transform: translateY(-12px) scale(0.95);
-		transition:
-			opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-			visibility 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-			transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-		pointer-events: none;
-	}
+        .dropdown-menu {
+                position: absolute;
+                top: calc(100% + var(--spacing-3));
+                left: 0;
+                z-index: var(--z-dropdown);
+                min-width: min(90vw, var(--content-width-xs));
+                width: max-content;
+                max-width: min(100vw, var(--content-width-sm));
+                background: rgba(var(--color-white-rgb), 0.95);
+                backdrop-filter: blur(var(--glass-blur-amount, 20px)) saturate(180%);
+                -webkit-backdrop-filter: blur(var(--glass-blur-amount, 20px)) saturate(180%);
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.4);
+                border-radius: var(--border-radius-lg);
+                box-shadow:
+                        var(--shadow-xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.6),
+                        inset 0 calc(-1 * var(--border-width-thin)) 0 rgba(var(--color-white-rgb), 0.2);
+                padding: var(--spacing-3);
+                opacity: 0;
+                visibility: hidden;
+                transform: translateY(calc(-1 * var(--spacing-3))) scale(0.95);
+                transition:
+                        opacity var(--anim-duration-base) var(--anim-ease-base),
+                        visibility var(--anim-duration-base) var(--anim-ease-base),
+                        transform var(--anim-duration-base) var(--anim-ease-base);
+                pointer-events: none;
+        }
 
 	.dropdown-menu.active {
 		opacity: 1;
@@ -83,40 +82,45 @@
 		margin: 0;
 	}
 
-	:global(.dropdown-item) {
-		display: block;
-		padding: var(--spacing-3) var(--spacing-4);
-		color: var(--color-text);
-		text-decoration: none;
-		font-size: var(--font-size-sm);
-		font-weight: 500;
-		border-radius: var(--border-radius-md);
-		transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-		margin-bottom: var(--spacing-2);
-		position: relative;
-		overflow: hidden;
-	}
+        :global(.dropdown-item) {
+                display: block;
+                padding: var(--spacing-3) var(--spacing-4);
+                color: var(--color-text);
+                text-decoration: none;
+                font-size: var(--font-size-sm);
+                font-weight: var(--font-weight-medium);
+                border-radius: var(--border-radius-md);
+                transition: all var(--anim-duration-base) var(--anim-ease-base);
+                margin-bottom: var(--spacing-2);
+                position: relative;
+                overflow: hidden;
+        }
 
-	:global(.dropdown-item::before) {
-		content: '';
-		position: absolute;
-		top: 0;
-		left: -100%;
-		width: 100%;
-		height: 100%;
-		background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
-		transition: left 0.5s ease;
-	}
+        :global(.dropdown-item::before) {
+                content: '';
+                position: absolute;
+                top: 0;
+                left: -100%;
+                width: 100%;
+                height: 100%;
+                background: linear-gradient(
+                        90deg,
+                        transparent,
+                        rgba(var(--color-white-rgb), 0.4),
+                        transparent
+                );
+                transition: left var(--anim-duration-slow) var(--anim-ease-base);
+        }
 
-	:global(.dropdown-item:hover),
-	:global(.dropdown-item:focus) {
-		background: rgba(var(--color-primary-rgb), 0.1);
-		color: var(--color-primary);
-		transform: translateX(6px) scale(1.02);
-		box-shadow:
-			0 4px 16px 0 rgba(var(--color-primary-rgb), 0.2),
-			inset 0 1px 0 rgba(255, 255, 255, 0.3);
-	}
+        :global(.dropdown-item:hover),
+        :global(.dropdown-item:focus) {
+                background: rgba(var(--color-primary-rgb), 0.1);
+                color: var(--color-primary);
+                transform: translateX(var(--spacing-2)) scale(1.02);
+                box-shadow:
+                        var(--shadow-lg),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.3);
+        }
 
 	:global(.dropdown-item:hover::before) {
 		left: 100%;
@@ -127,19 +131,23 @@
 	}
 
 	/* Dark mode */
-	:global(html.dark) .dropdown-menu {
-		background: rgba(var(--color-dark-surface-rgb), 0.9);
-		border: 1px solid rgba(255, 255, 255, 0.2);
-		box-shadow:
-			0 20px 60px 0 rgba(0, 0, 0, 0.4),
-			0 8px 32px 0 rgba(0, 0, 0, 0.3),
-			inset 0 1px 0 rgba(255, 255, 255, 0.2),
-			inset 0 -1px 0 rgba(255, 255, 255, 0.1);
-	}
+        :global(html.dark) .dropdown-menu {
+                background: rgba(var(--color-dark-surface-rgb), 0.9);
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.2);
+                box-shadow:
+                        var(--shadow-xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.2),
+                        inset 0 calc(-1 * var(--border-width-thin)) 0 rgba(var(--color-white-rgb), 0.1);
+        }
 
-	:global(html.dark .dropdown-item::before) {
-		background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-	}
+        :global(html.dark .dropdown-item::before) {
+                background: linear-gradient(
+                        90deg,
+                        transparent,
+                        rgba(var(--color-white-rgb), 0.2),
+                        transparent
+                );
+        }
 
 	/* Touch device optimizations */
 	@media (hover: none) {
@@ -156,27 +164,27 @@
 	}
 
 	/* Animation keyframes */
-	@keyframes dropdownFadeIn {
-		from {
-			opacity: 0;
-			transform: translateY(-12px) scale(0.95);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0) scale(1);
-		}
-	}
+        @keyframes dropdownFadeIn {
+                from {
+                        opacity: 0;
+                        transform: translateY(calc(-1 * var(--spacing-3))) scale(0.95);
+                }
+                to {
+                        opacity: 1;
+                        transform: translateY(0) scale(1);
+                }
+        }
 
-	.dropdown-menu.active {
-		animation: dropdownFadeIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-	}
+        .dropdown-menu.active {
+                animation: dropdownFadeIn var(--anim-duration-base) var(--anim-ease-base) forwards;
+        }
 
-	/* Staggered item animation */
-	:global(.dropdown-item) {
-		opacity: 0;
-		transform: translateX(-10px);
-		animation: dropdownItemFadeIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-	}
+        /* Staggered item animation */
+        :global(.dropdown-item) {
+                opacity: 0;
+                transform: translateX(calc(-1 * (var(--spacing-2) + var(--spacing-0\.5))));
+                animation: dropdownItemFadeIn var(--anim-duration-base) var(--anim-ease-base) forwards;
+        }
 
 	.dropdown-menu.active :global(.dropdown-item:nth-child(1)) {
 		animation-delay: 0.05s;
@@ -194,14 +202,14 @@
 		animation-delay: 0.2s;
 	}
 
-	@keyframes dropdownItemFadeIn {
-		from {
-			opacity: 0;
-			transform: translateX(-10px);
-		}
-		to {
-			opacity: 1;
-			transform: translateX(0);
-		}
+        @keyframes dropdownItemFadeIn {
+                from {
+                        opacity: 0;
+                        transform: translateX(calc(-1 * (var(--spacing-2) + var(--spacing-0\.5))));
+                }
+                to {
+                        opacity: 1;
+                        transform: translateX(0);
+                }
 	}
 </style>

--- a/src/lib/components/menu/HamburgerButton.svelte
+++ b/src/lib/components/menu/HamburgerButton.svelte
@@ -22,62 +22,62 @@
 </button>
 
 <style>
-	.hamburger {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		width: 28px;
-		height: 28px;
-		background: transparent;
-		border: none;
-		cursor: pointer;
-		padding: 0;
-		z-index: 150;
-		position: relative;
-		gap: 4px;
-	}
+        .hamburger {
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                width: calc(var(--spacing-6) + var(--spacing-1));
+                height: calc(var(--spacing-6) + var(--spacing-1));
+                background: transparent;
+                border: none;
+                cursor: pointer;
+                padding: 0;
+                z-index: var(--z-fixed);
+                position: relative;
+                gap: var(--spacing-1);
+        }
 
-	.hamburger-line {
-		width: 100%;
-		height: 2px;
-		background-color: var(--color-text);
-		transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-		transform-origin: center;
-	}
+        .hamburger-line {
+                width: 100%;
+                height: var(--border-width-medium);
+                background-color: var(--color-text);
+                transition: all var(--anim-duration-base) var(--anim-ease-base);
+                transform-origin: center;
+        }
 
 	/* Hamburger to X animation */
-	.hamburger.active .hamburger-line:first-child {
-		transform: translateY(6px) rotate(45deg);
-	}
+        .hamburger.active .hamburger-line:first-child {
+                transform: translateY(calc(var(--spacing-2) - var(--spacing-0\.5))) rotate(45deg);
+        }
 
-	.hamburger.active .hamburger-line:nth-child(2) {
-		opacity: 0;
-		transform: scaleX(0);
-	}
+        .hamburger.active .hamburger-line:nth-child(2) {
+                opacity: 0;
+                transform: scaleX(0);
+        }
 
-	.hamburger.active .hamburger-line:last-child {
-		transform: translateY(-6px) rotate(-45deg);
-	}
+        .hamburger.active .hamburger-line:last-child {
+                transform: translateY(calc(-1 * (var(--spacing-2) - var(--spacing-0\.5)))) rotate(-45deg);
+        }
 
-	/* Hide hamburger on desktop */
-	@media (min-width: 1024px) {
-		.hamburger {
-			display: none;
-		}
-	}
+        /* Hide hamburger on desktop */
+        @media (min-width: 56rem) {
+                .hamburger {
+                        display: none;
+                }
+        }
 
-	.hamburger:focus-visible {
-		outline: 2px solid var(--color-primary);
-		outline-offset: 2px;
-		border-radius: var(--border-radius-sm);
-	}
+        .hamburger:focus-visible {
+                outline: var(--border-width-medium) solid var(--color-primary);
+                outline-offset: var(--spacing-1);
+                border-radius: var(--border-radius-sm);
+        }
 
-	/* High contrast mode support */
-	@media (prefers-contrast: high) {
-		.hamburger-line {
-			height: 3px;
-		}
-	}
+        /* High contrast mode support */
+        @media (prefers-contrast: high) {
+                .hamburger-line {
+                        height: calc(var(--border-width-medium) + var(--border-width-thin));
+                }
+        }
 
 	/* Reduced motion support */
 	@media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/menu/Header.svelte
+++ b/src/lib/components/menu/Header.svelte
@@ -56,7 +56,7 @@
 	let dropdownTimer = $state<ReturnType<typeof setTimeout> | null>(null);
 	let bodyOverflowHidden = $state(false);
 
-	const HIDE_DELAY = 200;
+        const HIDE_DELAY = 200;
 
 	// Dropdown handlers
 	function showDropdown(index: number) {
@@ -137,12 +137,12 @@
 	}
 
 	// Window resize handler
-	function handleResize() {
-		const mobileBreakpoint = 768;
-		if (window.innerWidth >= mobileBreakpoint && mobileMenuOpen) {
-			closeMobileMenu();
-		}
-	}
+        function handleResize() {
+                const mobileBreakpoint = 896; // Match 56rem desktop breakpoint
+                if (window.innerWidth >= mobileBreakpoint && mobileMenuOpen) {
+                        closeMobileMenu();
+                }
+        }
 
 	// Lifecycle
 	$effect(() => {
@@ -197,125 +197,125 @@
 </header>
 
 <style>
-	/* Site Header Styles */
-	:global(.site-header) {
-		background: linear-gradient(
-			135deg,
-			rgba(255, 255, 255, 0.8) 0%,
-			rgba(var(--color-primary-rgb), 0.02) 50%,
-			rgba(var(--color-highlight-rgb), 0.01) 100%
-		);
-		backdrop-filter: blur(20px);
-		-webkit-backdrop-filter: blur(20px);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-		box-shadow:
-			0 4px 24px 0 rgba(31, 38, 135, 0.15),
-			inset 0 1px 0 rgba(255, 255, 255, 0.4);
-		position: sticky;
-		top: 0;
-		z-index: 100;
-		transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-	}
+        /* Site Header Styles */
+        :global(.site-header) {
+                background: linear-gradient(
+                        135deg,
+                        rgba(var(--color-white-rgb), 0.8) 0%,
+                        rgba(var(--color-primary-rgb), 0.02) 50%,
+                        rgba(var(--color-highlight-rgb), 0.01) 100%
+                );
+                backdrop-filter: blur(var(--glass-blur-amount, 20px));
+                -webkit-backdrop-filter: blur(var(--glass-blur-amount, 20px));
+                border-bottom: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.3);
+                box-shadow:
+                        var(--shadow-lg),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.4);
+                position: sticky;
+                top: 0;
+                z-index: var(--z-sticky);
+                transition: all var(--anim-duration-base) var(--anim-ease-base);
+        }
 
-	:global(.site-header:hover) {
-		background: linear-gradient(
-			135deg,
-			rgba(255, 255, 255, 0.9) 0%,
-			rgba(var(--color-primary-rgb), 0.03) 50%,
-			rgba(var(--color-highlight-rgb), 0.02) 100%
-		);
-		border-bottom-color: rgba(255, 255, 255, 0.4);
-		box-shadow:
-			0 6px 32px 0 rgba(31, 38, 135, 0.2),
-			inset 0 1px 0 rgba(255, 255, 255, 0.5);
-	}
+        :global(.site-header:hover) {
+                background: linear-gradient(
+                        135deg,
+                        rgba(var(--color-white-rgb), 0.9) 0%,
+                        rgba(var(--color-primary-rgb), 0.03) 50%,
+                        rgba(var(--color-highlight-rgb), 0.02) 100%
+                );
+                border-bottom-color: rgba(var(--color-white-rgb), 0.4);
+                box-shadow:
+                        var(--shadow-xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.5);
+        }
 
-	/* Dark mode */
-	:global(html.dark .site-header) {
-		background: linear-gradient(
-			135deg,
-			rgba(var(--color-dark-surface-rgb), 0.8) 0%,
-			rgba(var(--color-primary-rgb), 0.04) 50%,
-			rgba(var(--color-highlight-rgb), 0.02) 100%
-		);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-		box-shadow:
-			0 4px 24px 0 rgba(0, 0, 0, 0.4),
-			inset 0 1px 0 rgba(255, 255, 255, 0.1);
-	}
+        /* Dark mode */
+        :global(html.dark .site-header) {
+                background: linear-gradient(
+                        135deg,
+                        rgba(var(--color-dark-surface-rgb), 0.8) 0%,
+                        rgba(var(--color-primary-rgb), 0.04) 50%,
+                        rgba(var(--color-highlight-rgb), 0.02) 100%
+                );
+                border-bottom: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.15);
+                box-shadow:
+                        var(--shadow-lg),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.1);
+        }
 
-	:global(html.dark .site-header:hover) {
-		background: linear-gradient(
-			135deg,
-			rgba(var(--color-dark-surface-rgb), 0.85) 0%,
-			rgba(var(--color-primary-rgb), 0.06) 50%,
-			rgba(var(--color-highlight-rgb), 0.03) 100%
-		);
-		border-bottom-color: rgba(255, 255, 255, 0.2);
-		box-shadow:
-			0 6px 32px 0 rgba(0, 0, 0, 0.5),
-			inset 0 1px 0 rgba(255, 255, 255, 0.15);
-	}
+        :global(html.dark .site-header:hover) {
+                background: linear-gradient(
+                        135deg,
+                        rgba(var(--color-dark-surface-rgb), 0.85) 0%,
+                        rgba(var(--color-primary-rgb), 0.06) 50%,
+                        rgba(var(--color-highlight-rgb), 0.03) 100%
+                );
+                border-bottom-color: rgba(var(--color-white-rgb), 0.2);
+                box-shadow:
+                        var(--shadow-xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.15);
+        }
 
-	.container {
-		max-width: 1280px;
-		width: 100%;
-		margin-left: auto;
-		margin-right: auto;
-		padding: 0 var(--spacing-4);
-	}
+        .container {
+                max-width: var(--container-xl);
+                width: 100%;
+                margin-left: auto;
+                margin-right: auto;
+                padding: 0 var(--spacing-4);
+        }
 
-	.header-inner {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: var(--spacing-4) 0;
-		position: relative;
-		height: 64px;
-	}
+        .header-inner {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: var(--spacing-4) 0;
+                position: relative;
+                min-height: var(--spacing-16);
+        }
 
-	.header-logo {
-		flex-shrink: 0;
-		display: flex;
-		align-items: center;
-	}
+        .header-logo {
+                flex-shrink: 0;
+                display: flex;
+                align-items: center;
+        }
 
-	.header-logo :global(.site-title) {
-		font-size: var(--font-size-xl);
-		font-weight: 700;
-		color: var(--color-text);
-		text-decoration: none;
-		transition: color 0.2s ease;
-	}
+        .header-logo :global(.site-title) {
+                font-size: var(--font-size-xl);
+                font-weight: var(--font-weight-bold);
+                color: var(--color-text);
+                text-decoration: none;
+                transition: color var(--anim-duration-fast) var(--anim-ease-base);
+        }
 
-	.header-logo :global(.site-title:hover) {
-		color: var(--color-primary);
-	}
+        .header-logo :global(.site-title:hover) {
+                color: var(--color-primary);
+        }
 
-	.desktop-controls {
-		display: none;
-		align-items: center;
-		gap: var(--spacing-6);
-	}
+        .desktop-controls {
+                display: none;
+                align-items: center;
+                gap: var(--spacing-6);
+        }
 
-	@media (min-width: 640px) {
-		.container {
-			padding: 0 var(--spacing-6);
-		}
-	}
+        @media (min-width: 40rem) {
+                .container {
+                        padding: 0 var(--spacing-6);
+                }
+        }
 
-	@media (min-width: 1024px) {
-		.header-inner {
-			height: 72px;
-		}
+        @media (min-width: 56rem) {
+                .header-inner {
+                        min-height: calc(var(--spacing-16) + var(--spacing-2));
+                }
 
-		.desktop-controls {
-			display: flex;
-		}
-	}
+                .desktop-controls {
+                        display: flex;
+                }
+        }
 
-	/* Theme toggle spacing */
-	.desktop-controls :global(.theme-toggle) {
-		margin-left: var(--spacing-4);
-	}
+        /* Theme toggle spacing */
+        .desktop-controls :global(.theme-toggle) {
+                margin-left: var(--spacing-4);
+        }
 </style>

--- a/src/lib/components/menu/MobileMenu.svelte
+++ b/src/lib/components/menu/MobileMenu.svelte
@@ -60,106 +60,107 @@
 </div>
 
 <style>
-	.mobile-nav-container {
-		position: fixed;
-		top: 0;
-		left: 0;
-		height: 100vh;
-		width: 100%;
-		background: rgba(255, 255, 255, 0.98);
-		backdrop-filter: blur(32px) saturate(180%);
-		-webkit-backdrop-filter: blur(32px) saturate(180%);
-		z-index: 200;
-		transform: translateY(-100%);
-		transition: transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-		overflow-y: auto;
-		box-shadow:
-			0 0 60px rgba(31, 38, 135, 0.1),
-			inset 0 1px 0 rgba(255, 255, 255, 0.8);
-		will-change: transform;
-	}
+        .mobile-nav-container {
+                position: fixed;
+                top: 0;
+                left: 0;
+                height: 100vh;
+                width: 100%;
+                background: rgba(var(--color-white-rgb), 0.98);
+                backdrop-filter: blur(var(--glass-blur-amount, 32px)) saturate(180%);
+                -webkit-backdrop-filter: blur(var(--glass-blur-amount, 32px)) saturate(180%);
+                z-index: var(--z-modal);
+                transform: translateY(-100%);
+                transition: transform var(--anim-duration-base) var(--anim-ease-in-out);
+                overflow-y: auto;
+                box-shadow:
+                        var(--shadow-2xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.8);
+                will-change: transform;
+        }
 
 	.mobile-nav-container.active {
 		transform: translateY(0);
 	}
 
-	.mobile-nav {
-		padding: var(--spacing-4);
-		height: 100%;
-		display: flex;
-		flex-direction: column;
-	}
+        .mobile-nav {
+                padding: var(--spacing-4);
+                height: 100%;
+                display: flex;
+                flex-direction: column;
+                gap: var(--spacing-4);
+        }
 
-	.mobile-nav-header {
-		display: grid;
-		grid-template-columns: 1fr auto 1fr;
-		align-items: center;
-		margin-bottom: 0;
-		padding: var(--spacing-4) var(--spacing-2);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-		background: rgba(255, 255, 255, 0.98);
-		backdrop-filter: blur(32px) saturate(180%);
-		-webkit-backdrop-filter: blur(32px) saturate(180%);
-		position: sticky;
-		top: 0;
-		z-index: 10;
-		box-shadow: 0 2px 8px rgba(31, 38, 135, 0.1);
-	}
+        .mobile-nav-header {
+                display: grid;
+                grid-template-columns: 1fr auto 1fr;
+                align-items: center;
+                margin-bottom: 0;
+                padding: var(--spacing-4) var(--spacing-2);
+                border-bottom: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.2);
+                background: rgba(var(--color-white-rgb), 0.98);
+                backdrop-filter: blur(var(--glass-blur-amount, 32px)) saturate(180%);
+                -webkit-backdrop-filter: blur(var(--glass-blur-amount, 32px)) saturate(180%);
+                position: sticky;
+                top: 0;
+                z-index: 10;
+                box-shadow: var(--shadow);
+        }
 
-	.mobile-close-line {
-		width: 20px;
-		height: 2px;
-		background-color: var(--color-text);
-		position: absolute;
-		transition: all 0.3s ease;
-	}
+        .mobile-close-line {
+                width: calc(var(--spacing-6) - var(--spacing-1));
+                height: var(--border-width-medium);
+                background-color: var(--color-text);
+                position: absolute;
+                transition: all var(--anim-duration-base) var(--anim-ease-base);
+        }
 
 	.mobile-close-line:first-child {
 		transform: rotate(45deg);
 	}
 
-	.mobile-close-line:last-child {
-		transform: rotate(-45deg);
-	}
+        .mobile-close-line:last-child {
+                transform: rotate(-45deg);
+        }
 
-	.mobile-close-button:focus-visible {
-		outline: 2px solid var(--color-primary);
-		outline-offset: 2px;
-		border-radius: var(--border-radius-sm);
-	}
+        .mobile-close-button:focus-visible {
+                outline: var(--border-width-medium) solid var(--color-primary);
+                outline-offset: var(--spacing-1);
+                border-radius: var(--border-radius-sm);
+        }
 
 	:global(.mobile-nav-header .theme-toggle) {
 		justify-self: start;
 	}
 
-	:global(.mobile-site-title) {
-		font-size: var(--font-size-lg);
-		font-weight: 700;
-		color: var(--color-text);
-		text-decoration: none;
-		transition: color 0.2s ease;
-		justify-self: center;
-		text-align: center;
-	}
+        :global(.mobile-site-title) {
+                font-size: var(--font-size-lg);
+                font-weight: var(--font-weight-bold);
+                color: var(--color-text);
+                text-decoration: none;
+                transition: color var(--anim-duration-fast) var(--anim-ease-base);
+                justify-self: center;
+                text-align: center;
+        }
 
 	:global(.mobile-site-title:hover) {
 		color: var(--color-primary);
 	}
 
-	.mobile-close-button {
-		background: none;
-		border: none;
-		cursor: pointer;
-		padding: var(--spacing-1);
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		width: 24px;
-		height: 24px;
-		position: relative;
-		justify-self: end;
-	}
+        .mobile-close-button {
+                background: none;
+                border: none;
+                cursor: pointer;
+                padding: var(--spacing-1);
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+                width: var(--spacing-6);
+                height: var(--spacing-6);
+                position: relative;
+                justify-self: end;
+        }
 
 	:global(.mobile-nav-list) {
 		list-style: none;
@@ -168,15 +169,17 @@
 		flex: 1;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-2);
-	}
+                gap: var(--spacing-2);
+        }
 
-	:global(.mobile-nav-item) {
-		opacity: 0;
-		transform: translateX(-20px);
-		transition: all 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-		will-change: opacity, transform;
-	}
+        :global(.mobile-nav-item) {
+                opacity: 0;
+                transform: translateX(calc(-1 * var(--spacing-6)));
+                transition:
+                        transform var(--anim-duration-base) var(--anim-ease-out),
+                        opacity var(--anim-duration-base) var(--anim-ease-out);
+                will-change: opacity, transform;
+        }
 
 	.mobile-nav-container.active :global(.mobile-nav-item) {
 		opacity: 1;
@@ -199,9 +202,9 @@
 	.mobile-nav-container.active :global(.mobile-nav-item:nth-child(5)) {
 		transition-delay: 0.17s;
 	}
-	.mobile-nav-container.active :global(.mobile-nav-item:nth-child(6)) {
-		transition-delay: 0.2s;
-	}
+        .mobile-nav-container.active :global(.mobile-nav-item:nth-child(6)) {
+                transition-delay: var(--anim-duration-fast);
+        }
 	.mobile-nav-container.active :global(.mobile-nav-item:nth-child(7)) {
 		transition-delay: 0.23s;
 	}
@@ -211,99 +214,104 @@
 		padding-top: var(--spacing-4);
 	}
 
-	:global(.mobile-nav-link) {
-		display: block;
-		padding: var(--spacing-4) var(--spacing-6);
-		color: var(--color-text);
-		text-decoration: none;
-		font-size: var(--font-size-lg);
-		font-weight: 600;
-		border-radius: var(--border-radius-lg);
-		background: rgba(255, 255, 255, 0.05);
-		backdrop-filter: blur(8px);
-		-webkit-backdrop-filter: blur(8px);
-		border: 1px solid rgba(255, 255, 255, 0.1);
-		margin: var(--spacing-2) var(--spacing-4);
-		transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-		position: relative;
-		overflow: hidden;
-		will-change: transform, background-color, border-color;
-	}
+        :global(.mobile-nav-link) {
+                display: block;
+                padding: var(--spacing-4) var(--spacing-6);
+                color: var(--color-text);
+                text-decoration: none;
+                font-size: var(--font-size-lg);
+                font-weight: var(--font-weight-semibold);
+                border-radius: var(--border-radius-lg);
+                background: rgba(var(--color-white-rgb), 0.05);
+                backdrop-filter: blur(var(--glass-blur-amount, 8px));
+                -webkit-backdrop-filter: blur(var(--glass-blur-amount, 8px));
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.1);
+                margin: var(--spacing-2) var(--spacing-4);
+                transition: all var(--anim-duration-fast) var(--anim-ease-in-out);
+                position: relative;
+                overflow: hidden;
+                will-change: transform, background-color, border-color;
+        }
 
-	:global(.mobile-nav-link::before) {
-		content: '';
-		position: absolute;
-		top: 0;
-		left: -100%;
-		width: 100%;
-		height: 100%;
-		background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
-		transition: left 0.6s ease;
-	}
+        :global(.mobile-nav-link::before) {
+                content: '';
+                position: absolute;
+                top: 0;
+                left: -100%;
+                width: 100%;
+                height: 100%;
+                background: linear-gradient(
+                        90deg,
+                        transparent,
+                        rgba(var(--color-white-rgb), 0.3),
+                        transparent
+                );
+                transition: left var(--anim-duration-slow) var(--anim-ease-in-out);
+        }
 
-	:global(.mobile-nav-link:hover),
-	:global(.mobile-nav-link:focus) {
-		color: var(--color-primary);
-		background: rgba(var(--color-primary-rgb), 0.1);
-		border-color: rgba(var(--color-primary-rgb), 0.3);
-		transform: translateX(8px) scale(1.02);
-		box-shadow:
-			0 8px 32px 0 rgba(var(--color-primary-rgb), 0.2),
-			inset 0 1px 0 rgba(255, 255, 255, 0.4);
-	}
+        :global(.mobile-nav-link:hover),
+        :global(.mobile-nav-link:focus) {
+                color: var(--color-primary);
+                background: rgba(var(--color-primary-rgb), 0.1);
+                border-color: rgba(var(--color-primary-rgb), 0.3);
+                transform: translateX(var(--spacing-2)) scale(1.02);
+                box-shadow:
+                        var(--shadow-xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.4);
+        }
 
 	:global(.mobile-nav-link:hover::before) {
 		left: 100%;
 	}
 
-	:global(.mobile-dropdown) {
-		list-style: none;
-		padding: var(--spacing-3);
-		margin: var(--spacing-3) var(--spacing-6);
-		background: rgba(255, 255, 255, 0.08);
-		backdrop-filter: blur(12px);
-		-webkit-backdrop-filter: blur(12px);
-		border: 1px solid rgba(255, 255, 255, 0.15);
-		border-radius: var(--border-radius-md);
-		box-shadow:
-			0 8px 32px 0 rgba(31, 38, 135, 0.1),
-			inset 0 1px 0 rgba(255, 255, 255, 0.3);
-	}
+        :global(.mobile-dropdown) {
+                list-style: none;
+                padding: var(--spacing-3);
+                margin: var(--spacing-3) var(--spacing-6);
+                background: rgba(var(--color-white-rgb), 0.08);
+                backdrop-filter: blur(var(--glass-blur-amount, 12px));
+                -webkit-backdrop-filter: blur(var(--glass-blur-amount, 12px));
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.15);
+                border-radius: var(--border-radius-md);
+                box-shadow:
+                        var(--shadow-xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.3);
+        }
 
-	:global(.mobile-dropdown-link) {
-		display: block;
-		padding: var(--spacing-3) var(--spacing-4);
-		color: var(--color-text-light);
-		text-decoration: none;
-		font-size: var(--font-size-base);
-		font-weight: 500;
-		transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-		border-radius: var(--border-radius-sm);
-		margin-bottom: var(--spacing-1);
-		position: relative;
-		background: rgba(255, 255, 255, 0.03);
-		border: 1px solid rgba(255, 255, 255, 0.05);
-		will-change: transform, background-color, border-color;
-	}
+        :global(.mobile-dropdown-link) {
+                display: block;
+                padding: var(--spacing-3) var(--spacing-4);
+                color: var(--color-text-light);
+                text-decoration: none;
+                font-size: var(--font-size-base);
+                font-weight: var(--font-weight-medium);
+                transition: all var(--anim-duration-fast) var(--anim-ease-in-out);
+                border-radius: var(--border-radius-sm);
+                margin-bottom: var(--spacing-1);
+                position: relative;
+                background: rgba(var(--color-white-rgb), 0.03);
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.05);
+                will-change: transform, background-color, border-color;
+        }
 
-	:global(.mobile-dropdown-link::before) {
-		content: '→';
-		position: absolute;
-		left: -var(--spacing-3);
-		opacity: 0;
-		transition: all 0.2s ease;
-	}
+        :global(.mobile-dropdown-link::before) {
+                content: '→';
+                position: absolute;
+                left: calc(-1 * var(--spacing-3));
+                opacity: 0;
+                transition: all var(--anim-duration-fast) var(--anim-ease-base);
+        }
 
 	:global(.mobile-dropdown-link:hover),
-	:global(.mobile-dropdown-link:focus) {
-		color: var(--color-primary);
-		background: rgba(var(--color-primary-rgb), 0.08);
-		border-color: rgba(var(--color-primary-rgb), 0.2);
-		transform: translateX(var(--spacing-3)) scale(1.02);
-		box-shadow:
-			0 4px 16px 0 rgba(var(--color-primary-rgb), 0.15),
-			inset 0 1px 0 rgba(255, 255, 255, 0.2);
-	}
+        :global(.mobile-dropdown-link:focus) {
+                color: var(--color-primary);
+                background: rgba(var(--color-primary-rgb), 0.08);
+                border-color: rgba(var(--color-primary-rgb), 0.2);
+                transform: translateX(var(--spacing-3)) scale(1.02);
+                box-shadow:
+                        var(--shadow-lg),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.2);
+        }
 
 	:global(.mobile-dropdown-link:hover::before),
 	:global(.mobile-dropdown-link:focus::before) {
@@ -311,47 +319,52 @@
 	}
 
 	/* Hide mobile nav on desktop */
-	@media (min-width: 1024px) {
-		.mobile-nav-container {
-			display: none;
-		}
-	}
+        @media (min-width: 56rem) {
+                .mobile-nav-container {
+                        display: none;
+                }
+        }
 
 	/* Dark mode */
-	:global(html.dark) .mobile-nav-container {
-		background: rgba(var(--color-dark-surface-rgb), 0.95);
-		box-shadow:
-			0 0 60px rgba(0, 0, 0, 0.5),
-			inset 0 1px 0 rgba(255, 255, 255, 0.1);
-	}
+        :global(html.dark) .mobile-nav-container {
+                background: rgba(var(--color-dark-surface-rgb), 0.95);
+                box-shadow:
+                        var(--shadow-2xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.1);
+        }
 
-	:global(html.dark) .mobile-nav-header {
-		background: rgba(var(--color-dark-surface-rgb), 0.98);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-	}
+        :global(html.dark) .mobile-nav-header {
+                background: rgba(var(--color-dark-surface-rgb), 0.98);
+                border-bottom: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.1);
+                box-shadow: var(--shadow);
+        }
 
-	:global(html.dark .mobile-nav-link) {
-		background: rgba(var(--color-dark-surface-rgb), 0.1);
-		border: 1px solid rgba(255, 255, 255, 0.05);
-	}
+        :global(html.dark .mobile-nav-link) {
+                background: rgba(var(--color-dark-surface-rgb), 0.1);
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.05);
+        }
 
-	:global(html.dark .mobile-nav-link::before) {
-		background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
-	}
+        :global(html.dark .mobile-nav-link::before) {
+                background: linear-gradient(
+                        90deg,
+                        transparent,
+                        rgba(var(--color-white-rgb), 0.1),
+                        transparent
+                );
+        }
 
-	:global(html.dark .mobile-dropdown) {
-		background: rgba(var(--color-dark-surface-rgb), 0.15);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		box-shadow:
-			0 8px 32px 0 rgba(0, 0, 0, 0.3),
-			inset 0 1px 0 rgba(255, 255, 255, 0.1);
-	}
+        :global(html.dark .mobile-dropdown) {
+                background: rgba(var(--color-dark-surface-rgb), 0.15);
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.08);
+                box-shadow:
+                        var(--shadow-xl),
+                        inset 0 var(--border-width-thin) 0 rgba(var(--color-white-rgb), 0.1);
+        }
 
-	:global(html.dark .mobile-dropdown-link) {
-		background: rgba(var(--color-dark-surface-rgb), 0.05);
-		border: 1px solid rgba(255, 255, 255, 0.03);
-	}
+        :global(html.dark .mobile-dropdown-link) {
+                background: rgba(var(--color-dark-surface-rgb), 0.05);
+                border: var(--border-width-thin) solid rgba(var(--color-white-rgb), 0.03);
+        }
 
 	/* Touch device optimizations */
 	@media (hover: none) {
@@ -376,23 +389,23 @@
 		}
 	}
 
-	@keyframes mobileNavItemFadeIn {
-		from {
-			opacity: 0;
-			transform: translateX(-20px);
-		}
-		to {
-			opacity: 1;
-			transform: translateX(0);
-		}
+        @keyframes mobileNavItemFadeIn {
+                from {
+                        opacity: 0;
+                        transform: translateX(calc(-1 * var(--spacing-5)));
+                }
+                to {
+                        opacity: 1;
+                        transform: translateX(0);
+                }
 	}
 
 	/* Use transform-based animations for better performance */
-	.mobile-nav-container.active {
-		animation: mobileNavSlideIn 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
-	}
+        .mobile-nav-container.active {
+                animation: mobileNavSlideIn var(--anim-duration-base) var(--anim-ease-in-out) forwards;
+        }
 
-	.mobile-nav-container.active :global(.mobile-nav-item) {
-		animation: mobileNavItemFadeIn 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
-	}
+        .mobile-nav-container.active :global(.mobile-nav-item) {
+                animation: mobileNavItemFadeIn var(--anim-duration-fast) var(--anim-ease-in-out) forwards;
+        }
 </style>

--- a/src/lib/components/menu/NavItemWithDropdown.svelte
+++ b/src/lib/components/menu/NavItemWithDropdown.svelte
@@ -62,15 +62,15 @@
 	}
 
 	/* Add a buffer zone below the nav link to prevent accidental dropdown closing */
-	.dropdown-hover-wrapper::after {
-		content: '';
-		position: absolute;
-		bottom: -10px;
-		left: 0;
-		width: 100%;
-		height: 10px;
-		background: transparent;
-	}
+        .dropdown-hover-wrapper::after {
+                content: '';
+                position: absolute;
+                bottom: calc(-1 * var(--spacing-3));
+                left: 0;
+                width: 100%;
+                height: var(--spacing-3);
+                background: transparent;
+        }
 
 	/* Ensure the nav item is properly positioned for its dropdown */
 	.nav-item {

--- a/src/lib/components/menu/NavLink.svelte
+++ b/src/lib/components/menu/NavLink.svelte
@@ -35,65 +35,65 @@
 </a>
 
 <style>
-	.nav-link {
-		color: var(--color-text);
-		text-decoration: none;
-		font-weight: 500;
-		font-size: var(--font-size-base);
-		padding: var(--spacing-2) 0;
-		transition: all 0.2s ease;
-		position: relative;
-		display: flex;
-		align-items: center;
-		gap: var(--spacing-1);
-	}
+        .nav-link {
+                color: var(--color-text);
+                text-decoration: none;
+                font-weight: var(--font-weight-medium);
+                font-size: var(--font-size-base);
+                padding: var(--spacing-2) 0;
+                transition: all var(--anim-duration-fast) var(--anim-ease-base);
+                position: relative;
+                display: flex;
+                align-items: center;
+                gap: var(--spacing-1);
+        }
 
-	.nav-link::after {
-		content: '';
-		position: absolute;
-		bottom: -2px;
-		left: 0;
-		width: 0;
-		height: 2px;
-		background-color: var(--color-primary);
-		transition: width 0.3s ease;
-	}
+        .nav-link::after {
+                content: '';
+                position: absolute;
+                bottom: calc(-1 * var(--spacing-0\.5));
+                left: 0;
+                width: 0;
+                height: var(--border-width-medium);
+                background-color: var(--color-primary);
+                transition: width var(--anim-duration-base) var(--anim-ease-base);
+        }
 
 	.nav-link:hover {
 		color: var(--color-primary);
 	}
 
-	.nav-link:hover::after {
-		width: 100%;
-	}
+        .nav-link:hover::after {
+                width: 100%;
+        }
 
-	.dropdown-icon {
-		display: inline-block;
-		font-size: 12px;
-		transition: transform 0.3s ease;
-		line-height: 1;
-	}
+        .dropdown-icon {
+                display: inline-block;
+                font-size: var(--font-size-xs);
+                transition: transform var(--anim-duration-base) var(--anim-ease-base);
+                line-height: 1;
+        }
 
-	.nav-link:focus-visible {
-		outline: 2px solid var(--color-primary);
-		outline-offset: 2px;
-	}
+        .nav-link:focus-visible {
+                outline: var(--border-width-medium) solid var(--color-primary);
+                outline-offset: var(--spacing-1);
+        }
 
 	@media (hover: none) {
 		/* Prevent hover state issues on touch devices */
-		.nav-link:hover::after {
-			width: 0;
-		}
+                .nav-link:hover::after {
+                        width: 0;
+                }
 
-		.nav-link:active::after {
-			width: 100%;
-		}
-	}
+                .nav-link:active::after {
+                        width: 100%;
+                }
+        }
 
-	/* High contrast mode support */
-	@media (prefers-contrast: high) {
-		.nav-link::after {
-			height: 3px;
-		}
-	}
+        /* High contrast mode support */
+        @media (prefers-contrast: high) {
+                .nav-link::after {
+                        height: calc(var(--border-width-medium) + var(--border-width-thin));
+                }
+        }
 </style>


### PR DESCRIPTION
## Summary
- update header, desktop, and mobile navigation styles to use shared design tokens for spacing, shadows, borders, and motion
- adjust the desktop breakpoint to 56rem and sync resize logic so the mobile menu appears earlier on tablets
- align dropdown and mobile menu animations with system durations and easing for smoother interactions

## Testing
- npm run check *(fails: existing svelte-check type errors in conference and publications routes)*

------
https://chatgpt.com/codex/tasks/task_e_68e672754118833197583a12a637da4b