### PR TITLE
chore(ci): improve dependabot config and deploy workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,10 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
+    reviewers:
+      - 'fmadore'
     labels:
       - 'dependencies'
-      - 'security'
     commit-message:
       prefix: 'chore(deps)'
     # Prioritize security updates
@@ -40,8 +41,18 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    reviewers:
+      - 'fmadore'
     labels:
       - 'dependencies'
       - 'ci'
     commit-message:
       prefix: 'chore(ci)'
+    groups:
+      # Group all GitHub Actions updates together
+      actions-updates:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,6 @@ concurrency:
   group: 'pages'
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: Build
@@ -28,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Cache SvelteKit artifacts
@@ -50,6 +47,9 @@ jobs:
       - name: Run linters
         run: npm run lint
 
+      - name: Type-check
+        run: npm run check
+
       - name: Build with SvelteKit
         run: npm run build
 
@@ -57,7 +57,7 @@ jobs:
         run: touch build/.nojekyll
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./build
 


### PR DESCRIPTION
## Summary

- **Upgrade Node.js from 20 (EOL) to 24 LTS** in deploy workflow
- **Add type-checking step** (`npm run check`) before build to catch TypeScript/Svelte errors in CI
- **Update `upload-pages-artifact`** from v4 to v5
- **Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** env var (no longer needed with Node 24 as standard)
- **Add `reviewers: fmadore`** to both Dependabot ecosystems so PRs are auto-assigned
- **Remove blanket `security` label** from npm updates (Dependabot already auto-labels actual security PRs)
- **Group GitHub Actions minor/patch updates** into a single PR to reduce noise

## Test plan

- [ ] Verify deploy workflow runs successfully with Node 24
- [ ] Confirm `npm run check` passes in CI
- [ ] Confirm `upload-pages-artifact@v5` uploads correctly
- [ ] Verify next Dependabot PRs are assigned to `fmadore` and Actions updates are grouped

https://claude.ai/code/session_01L7Cj3j3hbwi46qRe2How6n