### PR TITLE
fix(ci): revert upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         run: touch build/.nojekyll
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./build
 


### PR DESCRIPTION
## Summary

- Reverts `actions/upload-pages-artifact` from v5 back to **v4** — v5 does not exist and the deploy workflow has been failing since PR #59 was merged

**Error:** `Unable to resolve action actions/upload-pages-artifact@v5, unable to find version v5`

This was my mistake in the previous PR. Apologies for the broken deploy.

## Test plan

- [ ] Verify the deploy workflow completes successfully after merge

https://claude.ai/code/session_01L7Cj3j3hbwi46qRe2How6n