### PR TITLE
refactor(nav): improve header readability, consistency, and a11y

### DIFF
--- a/src/lib/components/menu/DropdownMenu.svelte
+++ b/src/lib/components/menu/DropdownMenu.svelte
@@ -49,19 +49,18 @@
 		max-width: min(100vw, var(--content-width-sm));
 		background: color-mix(
 			in srgb,
-			var(--color-white) calc(var(--glass-opacity-fallback-light) * 100%),
+			var(--color-white) calc(var(--header-dropdown-opacity) * 100%),
 			transparent
 		);
-		backdrop-filter: blur(var(--glass-blur-amount, var(--glass-blur-fallback))) saturate(180%);
-		-webkit-backdrop-filter: blur(var(--glass-blur-amount, var(--glass-blur-fallback)))
-			saturate(180%);
+		backdrop-filter: blur(var(--header-blur, var(--header-blur-fallback))) saturate(180%);
+		-webkit-backdrop-filter: blur(var(--header-blur, var(--header-blur-fallback))) saturate(180%);
 		border: var(--border-width-thin) solid
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-40) * 100%), transparent);
+			color-mix(in srgb, var(--color-white) calc(var(--header-border-opacity) * 100%), transparent);
 		border-radius: var(--border-radius-lg);
 		box-shadow:
 			var(--shadow-xl),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-60) * 100%), transparent),
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent),
 			inset 0 calc(-1 * var(--border-width-thin)) 0
 				color-mix(in srgb, var(--color-white) calc(var(--opacity-20) * 100%), transparent);
 		padding: var(--space-3);
@@ -74,6 +73,13 @@
 			transform var(--duration-normal) var(--ease-out);
 		pointer-events: none;
 		will-change: opacity, transform, visibility;
+	}
+
+	/* Solid fallback for browsers without backdrop-filter support. */
+	@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+		.dropdown-menu {
+			background: var(--color-background);
+		}
 	}
 
 	.dropdown-menu.active {
@@ -141,8 +147,8 @@
 
 	:global(.dropdown-item:focus-visible) {
 		outline: var(--border-width-medium) solid var(--color-primary);
-		outline-offset: var(--space-1);
-		border-radius: var(--border-radius-sm);
+		outline-offset: var(--space-0-5);
+		border-radius: var(--border-radius-md);
 	}
 
 	:global(.dropdown-item:hover::before) {
@@ -157,15 +163,15 @@
 	:global(html.dark) .dropdown-menu {
 		background: color-mix(
 			in srgb,
-			var(--color-dark-surface) calc(var(--opacity-90) * 100%),
+			var(--color-dark-surface) calc(var(--header-dropdown-opacity) * 100%),
 			transparent
 		);
 		border: var(--border-width-thin) solid
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-20) * 100%), transparent);
+			color-mix(in srgb, var(--color-white) calc(var(--header-border-opacity) * 100%), transparent);
 		box-shadow:
 			var(--shadow-xl),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-20) * 100%), transparent),
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent),
 			inset 0 calc(-1 * var(--border-width-thin)) 0
 				color-mix(in srgb, var(--color-white) calc(var(--opacity-10) * 100%), transparent);
 	}

--- a/src/lib/components/menu/HamburgerButton.svelte
+++ b/src/lib/components/menu/HamburgerButton.svelte
@@ -43,7 +43,8 @@
 		background-color: var(--color-text);
 		transition:
 			transform var(--duration-normal) var(--ease-out),
-			opacity var(--duration-fast) var(--ease-out);
+			opacity var(--duration-fast) var(--ease-out),
+			background-color var(--duration-fast) var(--ease-out);
 		transform-origin: center;
 	}
 
@@ -78,7 +79,11 @@
 	.hamburger:focus-visible {
 		outline: var(--border-width-medium) solid var(--color-primary);
 		outline-offset: var(--space-1);
-		border-radius: var(--border-radius-sm);
+		border-radius: var(--border-radius-md);
+	}
+
+	.hamburger:hover .hamburger-line {
+		background-color: var(--color-primary);
 	}
 
 	/* High contrast mode support */

--- a/src/lib/components/menu/Header.svelte
+++ b/src/lib/components/menu/Header.svelte
@@ -18,13 +18,18 @@
 	// reveals on scroll up. Disabled while a dropdown or mobile menu is open
 	// so the header can't vanish mid-interaction.
 	let headerHidden = $state(false);
+	// Solid-ish state once the user has scrolled past the very top, so the
+	// header is reliably readable over body copy and images.
+	let headerScrolled = $state(false);
+	let headerEl: HTMLElement | null = $state(null);
 
 	// Current pathname, used for highlighting the active nav link.
 	const currentPath = $derived($page.url.pathname);
 
 	const HIDE_DELAY = 200;
-	const SCROLL_HIDE_THRESHOLD = 200; // px before we start hiding
-	const SCROLL_DELTA = 6; // min delta to consider a direction change
+	const SCROLL_HIDE_THRESHOLD = 120; // px before we start hiding
+	const SCROLL_DELTA = 10; // min delta to consider a direction change
+	const SCROLLED_STATE_THRESHOLD = 8; // px to switch to solid-ish background
 
 	// Dropdown handlers
 	function showDropdown(index: number) {
@@ -124,8 +129,21 @@
 			const currentY = window.scrollY;
 			const delta = currentY - lastScrollY;
 
-			// Never hide while menus/dropdowns are open, or near the top.
-			if (mobileMenuOpen || activeDropdown !== null || currentY < SCROLL_HIDE_THRESHOLD) {
+			headerScrolled = currentY > SCROLLED_STATE_THRESHOLD;
+
+			// Never hide while menus/dropdowns are open, near the top, or
+			// while keyboard focus lives inside the header.
+			const focusInsideHeader =
+				headerEl !== null &&
+				document.activeElement !== null &&
+				headerEl.contains(document.activeElement);
+
+			if (
+				mobileMenuOpen ||
+				activeDropdown !== null ||
+				focusInsideHeader ||
+				currentY < SCROLL_HIDE_THRESHOLD
+			) {
 				headerHidden = false;
 			} else if (Math.abs(delta) > SCROLL_DELTA) {
 				headerHidden = delta > 0; // hide on scroll down, show on scroll up
@@ -159,7 +177,12 @@
 
 <svelte:window onclick={handleClickOutside} />
 
-<header class="site-header" class:header-hidden={headerHidden}>
+<header
+	class="site-header"
+	class:header-hidden={headerHidden}
+	class:header-scrolled={headerScrolled}
+	bind:this={headerEl}
+>
 	<div class="container">
 		<div class="header-inner">
 			<div class="header-logo">
@@ -193,22 +216,35 @@
 </header>
 
 <style>
-	/* Site Header Styles */
+	/* Site Header Styles
+	 * Uses dedicated --header-* tokens so the navigation stays readable over
+	 * body text and images, rather than borrowing the card-oriented
+	 * --glass-opacity-* values which are intentionally very translucent. */
 	:global(.site-header) {
 		background: linear-gradient(
 			135deg,
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-95) * 100%), transparent) 0%,
-			color-mix(in srgb, var(--color-primary) 2%, transparent) 50%,
-			color-mix(in srgb, var(--color-highlight) 1%, transparent) 100%
+			color-mix(in srgb, var(--color-white) calc(var(--header-bg-opacity) * 100%), transparent) 0%,
+			color-mix(
+					in srgb,
+					var(--color-primary) 3%,
+					color-mix(in srgb, var(--color-white) calc(var(--header-bg-opacity) * 100%), transparent)
+				)
+				50%,
+			color-mix(
+					in srgb,
+					var(--color-highlight) 2%,
+					color-mix(in srgb, var(--color-white) calc(var(--header-bg-opacity) * 100%), transparent)
+				)
+				100%
 		);
-		backdrop-filter: blur(var(--glass-blur-amount, var(--glass-blur-fallback)));
-		-webkit-backdrop-filter: blur(var(--glass-blur-amount, var(--glass-blur-fallback)));
+		backdrop-filter: blur(var(--header-blur, var(--header-blur-fallback))) saturate(180%);
+		-webkit-backdrop-filter: blur(var(--header-blur, var(--header-blur-fallback))) saturate(180%);
 		border-bottom: var(--border-width-thin) solid
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-30) * 100%), transparent);
+			color-mix(in srgb, var(--color-white) calc(var(--header-border-opacity) * 100%), transparent);
 		box-shadow:
-			var(--shadow-lg),
+			var(--shadow-md),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-40) * 100%), transparent);
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
 		position: sticky;
 		top: 0;
 		z-index: var(--z-sticky);
@@ -219,6 +255,50 @@
 			border-color var(--duration-normal) var(--ease-out),
 			box-shadow var(--duration-normal) var(--ease-out);
 		will-change: transform;
+	}
+
+	/* Scrolled state: once the user has scrolled past the very top, raise the
+	 * background opacity and bottom-border so the header stays legible over
+	 * page content and asserts a clear separation. */
+	:global(.site-header.header-scrolled) {
+		background: linear-gradient(
+			135deg,
+			color-mix(
+					in srgb,
+					var(--color-white) calc(var(--header-bg-opacity-scrolled) * 100%),
+					transparent
+				)
+				0%,
+			color-mix(
+					in srgb,
+					var(--color-primary) 3%,
+					color-mix(
+						in srgb,
+						var(--color-white) calc(var(--header-bg-opacity-scrolled) * 100%),
+						transparent
+					)
+				)
+				50%,
+			color-mix(
+					in srgb,
+					var(--color-highlight) 2%,
+					color-mix(
+						in srgb,
+						var(--color-white) calc(var(--header-bg-opacity-scrolled) * 100%),
+						transparent
+					)
+				)
+				100%
+		);
+		border-bottom-color: color-mix(
+			in srgb,
+			var(--color-white) calc(var(--header-border-opacity-scrolled) * 100%),
+			transparent
+		);
+		box-shadow:
+			var(--shadow-lg),
+			inset 0 var(--border-width-thin) 0
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
 	}
 
 	/* Scroll-direction hide: transform rather than top/display so the
@@ -235,61 +315,95 @@
 		}
 	}
 
-	:global(.site-header:hover) {
-		background: linear-gradient(
-			135deg,
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-95) * 100%), transparent) 0%,
-			color-mix(in srgb, var(--color-primary) 3%, transparent) 50%,
-			color-mix(in srgb, var(--color-highlight) 2%, transparent) 100%
-		);
-		border-bottom-color: color-mix(
-			in srgb,
-			var(--color-white) calc(var(--opacity-40) * 100%),
-			transparent
-		);
-		box-shadow:
-			var(--shadow-xl),
-			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-50) * 100%), transparent);
-	}
-
 	/* Dark mode */
 	:global(html.dark .site-header) {
 		background: linear-gradient(
 			135deg,
-			color-mix(in srgb, var(--color-dark-surface) calc(var(--opacity-80) * 100%), transparent) 0%,
-			color-mix(in srgb, var(--color-primary) 4%, transparent) 50%,
-			color-mix(in srgb, var(--color-highlight) 2%, transparent) 100%
+			color-mix(
+					in srgb,
+					var(--color-dark-surface) calc(var(--header-bg-opacity) * 100%),
+					transparent
+				)
+				0%,
+			color-mix(
+					in srgb,
+					var(--color-primary) 5%,
+					color-mix(
+						in srgb,
+						var(--color-dark-surface) calc(var(--header-bg-opacity) * 100%),
+						transparent
+					)
+				)
+				50%,
+			color-mix(
+					in srgb,
+					var(--color-highlight) 3%,
+					color-mix(
+						in srgb,
+						var(--color-dark-surface) calc(var(--header-bg-opacity) * 100%),
+						transparent
+					)
+				)
+				100%
 		);
 		border-bottom: var(--border-width-thin) solid
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-15) * 100%), transparent);
+			color-mix(in srgb, var(--color-white) calc(var(--header-border-opacity) * 100%), transparent);
 		box-shadow:
-			var(--shadow-lg),
+			var(--shadow-md),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-10) * 100%), transparent);
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
 	}
 
-	:global(html.dark .site-header:hover) {
+	:global(html.dark .site-header.header-scrolled) {
 		background: linear-gradient(
 			135deg,
 			color-mix(
 					in srgb,
-					var(--color-dark-surface) calc(var(--glass-opacity-high) * 100%),
+					var(--color-dark-surface) calc(var(--header-bg-opacity-scrolled) * 100%),
 					transparent
 				)
 				0%,
-			color-mix(in srgb, var(--color-primary) 6%, transparent) 50%,
-			color-mix(in srgb, var(--color-highlight) 3%, transparent) 100%
+			color-mix(
+					in srgb,
+					var(--color-primary) 5%,
+					color-mix(
+						in srgb,
+						var(--color-dark-surface) calc(var(--header-bg-opacity-scrolled) * 100%),
+						transparent
+					)
+				)
+				50%,
+			color-mix(
+					in srgb,
+					var(--color-highlight) 3%,
+					color-mix(
+						in srgb,
+						var(--color-dark-surface) calc(var(--header-bg-opacity-scrolled) * 100%),
+						transparent
+					)
+				)
+				100%
 		);
 		border-bottom-color: color-mix(
 			in srgb,
-			var(--color-white) calc(var(--opacity-20) * 100%),
+			var(--color-white) calc(var(--header-border-opacity-scrolled) * 100%),
 			transparent
 		);
 		box-shadow:
-			var(--shadow-xl),
+			var(--shadow-lg),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-15) * 100%), transparent);
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
+	}
+
+	/* Solid fallback for browsers without backdrop-filter. */
+	@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+		:global(.site-header) {
+			background: var(--color-background);
+		}
+
+		:global(html.dark .site-header) {
+			background: var(--color-background);
+		}
 	}
 
 	.container {
@@ -304,15 +418,17 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		padding: var(--space-4) 0;
+		gap: var(--space-4);
+		padding: var(--space-3) 0;
 		position: relative;
-		min-height: var(--space-16);
+		min-height: var(--space-14);
 	}
 
 	.header-logo {
 		flex-shrink: 0;
 		display: flex;
 		align-items: center;
+		min-width: 0;
 	}
 
 	.header-logo :global(.site-title) {
@@ -321,10 +437,17 @@
 		color: var(--color-text);
 		text-decoration: none;
 		transition: color var(--duration-fast) var(--ease-out);
+		white-space: nowrap;
 	}
 
 	.header-logo :global(.site-title:hover) {
 		color: var(--color-primary);
+	}
+
+	.header-logo :global(.site-title:focus-visible) {
+		outline: var(--border-width-medium) solid var(--color-primary);
+		outline-offset: var(--space-1);
+		border-radius: var(--border-radius-sm);
 	}
 
 	.desktop-controls {
@@ -336,6 +459,11 @@
 	@media (--sm) {
 		.container {
 			padding: 0 var(--space-6);
+		}
+
+		.header-inner {
+			padding: var(--space-4) 0;
+			min-height: var(--space-16);
 		}
 	}
 
@@ -349,8 +477,9 @@
 		}
 	}
 
-	/* Theme toggle spacing */
+	/* Theme toggle sits to the right of the nav; keep rhythm consistent
+	 * with the --space-6 gap already present on .desktop-controls. */
 	.desktop-controls :global(.theme-toggle) {
-		margin-left: var(--space-4);
+		margin-left: 0;
 	}
 </style>

--- a/src/lib/components/menu/MobileMenu.svelte
+++ b/src/lib/components/menu/MobileMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import type { NavItem } from '$lib/types/navigation';
 	import ThemeToggle from '$lib/components/menu/ThemeToggle.svelte';
 	import { resolve } from '$app/paths';
@@ -12,9 +13,71 @@
 		isActive?: boolean;
 		onCloseMenu: () => void;
 	} = $props();
+
+	let containerEl: HTMLDivElement | null = $state(null);
+	let closeButtonEl: HTMLButtonElement | null = $state(null);
+	let previouslyFocused: HTMLElement | null = null;
+
+	// Move focus into the menu when it opens and restore it to the element
+	// that triggered opening (the hamburger) when it closes.
+	$effect(() => {
+		if (isActive) {
+			previouslyFocused = document.activeElement as HTMLElement | null;
+			tick().then(() => {
+				closeButtonEl?.focus();
+			});
+		} else if (previouslyFocused) {
+			previouslyFocused.focus?.();
+			previouslyFocused = null;
+		}
+	});
+
+	function getFocusable(): HTMLElement[] {
+		if (!containerEl) return [];
+		return Array.from(
+			containerEl.querySelectorAll<HTMLElement>(
+				'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+			)
+		).filter((el) => !el.hasAttribute('aria-hidden'));
+	}
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (!isActive) return;
+
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			onCloseMenu();
+			return;
+		}
+
+		if (event.key !== 'Tab') return;
+
+		const focusable = getFocusable();
+		if (focusable.length === 0) return;
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		const active = document.activeElement as HTMLElement | null;
+
+		if (event.shiftKey && active === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && active === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	}
 </script>
 
-<div id="mobile-menu" class="mobile-nav-container" class:active={isActive}>
+<svelte:window onkeydown={handleKeyDown} />
+
+<div
+	id="mobile-menu"
+	class="mobile-nav-container"
+	class:active={isActive}
+	bind:this={containerEl}
+	aria-hidden={isActive ? 'false' : 'true'}
+>
 	<nav class="mobile-nav" aria-label="Mobile navigation">
 		<!-- Mobile Menu Header -->
 		<div class="mobile-nav-header">
@@ -23,7 +86,12 @@
 			<a href={resolve('/')} class="mobile-site-title" onclick={onCloseMenu}> Frédérick Madore </a>
 
 			<!-- Close button -->
-			<button class="mobile-close-button" onclick={onCloseMenu} aria-label="Close navigation menu">
+			<button
+				class="mobile-close-button"
+				onclick={onCloseMenu}
+				aria-label="Close navigation menu"
+				bind:this={closeButtonEl}
+			>
 				<span class="mobile-close-line"></span>
 				<span class="mobile-close-line"></span>
 			</button>
@@ -73,12 +141,11 @@
 		width: 100%;
 		background: color-mix(
 			in srgb,
-			var(--color-white) calc(var(--glass-opacity-fallback-light) * 100%),
+			var(--color-white) calc(var(--header-overlay-opacity) * 100%),
 			transparent
 		);
-		backdrop-filter: blur(var(--glass-blur-amount, var(--glass-blur-fallback))) saturate(180%);
-		-webkit-backdrop-filter: blur(var(--glass-blur-amount, var(--glass-blur-fallback)))
-			saturate(180%);
+		backdrop-filter: blur(var(--header-blur, var(--header-blur-fallback))) saturate(180%);
+		-webkit-backdrop-filter: blur(var(--header-blur, var(--header-blur-fallback))) saturate(180%);
 		z-index: var(--z-modal);
 		transform: translateY(-100%);
 		transition: transform var(--duration-moderate) var(--ease-in-out);
@@ -86,8 +153,15 @@
 		box-shadow:
 			var(--shadow-2xl),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-80) * 100%), transparent);
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
 		will-change: transform;
+	}
+
+	/* Solid fallback for browsers without backdrop-filter support. */
+	@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+		.mobile-nav-container {
+			background: var(--color-background);
+		}
 	}
 
 	.mobile-nav-container.active {
@@ -105,23 +179,24 @@
 	.mobile-nav-header {
 		display: grid;
 		grid-template-columns: 1fr auto 1fr;
+		gap: var(--space-3);
 		align-items: center;
 		margin: var(--space-2);
 		padding: var(--space-3) var(--space-4);
 		background: linear-gradient(
 			135deg,
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-60) * 100%), transparent),
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-40) * 100%), transparent)
+			color-mix(in srgb, var(--color-white) calc(var(--opacity-80) * 100%), transparent),
+			color-mix(in srgb, var(--color-white) calc(var(--opacity-60) * 100%), transparent)
 		);
-		backdrop-filter: blur(var(--glass-blur-lg)) saturate(180%);
-		-webkit-backdrop-filter: blur(var(--glass-blur-lg)) saturate(180%);
+		backdrop-filter: blur(var(--header-blur)) saturate(180%);
+		-webkit-backdrop-filter: blur(var(--header-blur)) saturate(180%);
 		border: var(--border-width-thin) solid
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-50) * 100%), transparent);
+			color-mix(in srgb, var(--color-white) calc(var(--header-border-opacity) * 100%), transparent);
 		border-radius: var(--border-radius-xl);
 		box-shadow:
 			var(--shadow-md),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-60) * 100%), transparent);
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
 		position: sticky;
 		top: var(--space-2);
 		z-index: var(--z-above);
@@ -132,7 +207,13 @@
 		height: var(--border-width-medium);
 		background-color: var(--color-text);
 		position: absolute;
-		transition: transform var(--duration-normal) var(--ease-out);
+		transition:
+			transform var(--duration-normal) var(--ease-out),
+			background-color var(--duration-fast) var(--ease-out);
+	}
+
+	.mobile-close-button:hover .mobile-close-line {
+		background-color: var(--color-primary);
 	}
 
 	.mobile-close-line:first-child {
@@ -171,13 +252,13 @@
 		background: none;
 		border: none;
 		cursor: pointer;
-		padding: var(--space-1);
+		padding: 0;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
-		width: var(--space-6);
-		height: var(--space-6);
+		width: calc(var(--space-6) + var(--space-1));
+		height: calc(var(--space-6) + var(--space-1));
 		position: relative;
 		justify-self: end;
 	}
@@ -303,14 +384,14 @@
 		list-style: none;
 		padding: var(--space-2);
 		margin: var(--space-2) var(--space-5);
-		background: color-mix(in srgb, var(--color-white) calc(var(--opacity-10) * 100%), transparent);
+		background: color-mix(in srgb, var(--color-white) calc(var(--opacity-15) * 100%), transparent);
 		backdrop-filter: blur(var(--glass-blur-md));
 		-webkit-backdrop-filter: blur(var(--glass-blur-md));
 		border: var(--border-width-thin) solid
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-15) * 100%), transparent);
-		border-radius: var(--border-radius-md);
+			color-mix(in srgb, var(--color-white) calc(var(--opacity-20) * 100%), transparent);
+		border-radius: var(--border-radius-lg);
 		box-shadow:
-			var(--shadow-xl),
+			var(--shadow-md),
 			inset 0 var(--border-width-thin) 0
 				color-mix(in srgb, var(--color-white) calc(var(--opacity-30) * 100%), transparent);
 	}
@@ -328,7 +409,7 @@
 			border-color var(--duration-fast) var(--ease-out),
 			color var(--duration-fast) var(--ease-out),
 			box-shadow var(--duration-fast) var(--ease-out);
-		border-radius: var(--border-radius-sm);
+		border-radius: var(--border-radius-md);
 		margin-bottom: var(--space-1);
 		position: relative;
 		background: color-mix(in srgb, var(--color-white) calc(var(--opacity-5) * 100%), transparent);
@@ -367,27 +448,27 @@
 	:global(html.dark) .mobile-nav-container {
 		background: color-mix(
 			in srgb,
-			var(--color-dark-surface) calc(var(--opacity-95) * 100%),
+			var(--color-dark-surface) calc(var(--header-overlay-opacity) * 100%),
 			transparent
 		);
 		box-shadow:
 			var(--shadow-2xl),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-10) * 100%), transparent);
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
 	}
 
 	:global(html.dark) .mobile-nav-header {
 		background: linear-gradient(
 			135deg,
-			color-mix(in srgb, var(--color-dark-surface) calc(var(--opacity-70) * 100%), transparent),
-			color-mix(in srgb, var(--color-dark-surface) calc(var(--opacity-50) * 100%), transparent)
+			color-mix(in srgb, var(--color-dark-surface) calc(var(--opacity-80) * 100%), transparent),
+			color-mix(in srgb, var(--color-dark-surface) calc(var(--opacity-60) * 100%), transparent)
 		);
 		border: var(--border-width-thin) solid
-			color-mix(in srgb, var(--color-white) calc(var(--opacity-15) * 100%), transparent);
+			color-mix(in srgb, var(--color-white) calc(var(--header-border-opacity) * 100%), transparent);
 		box-shadow:
 			var(--shadow-lg),
 			inset 0 var(--border-width-thin) 0
-				color-mix(in srgb, var(--color-white) calc(var(--opacity-10) * 100%), transparent);
+				color-mix(in srgb, var(--color-white) calc(var(--header-inset-opacity) * 100%), transparent);
 	}
 
 	:global(html.dark .mobile-nav-link) {
@@ -478,8 +559,11 @@
 		animation: mobileNavItemReveal var(--duration-normal) var(--ease-out) forwards;
 	}
 
-	/* ===== REDUCED MOTION SUPPORT ===== */
-	/* Complete disable of animations for users who prefer reduced motion */
+	/* ===== REDUCED MOTION SUPPORT =====
+	 * Fully disable transitions/keyframes for users who ask for it. The
+	 * !important flags are intentional: they override the staggered transition
+	 * delays declared higher in this file and the keyframe animations
+	 * declared below. */
 	@media (prefers-reduced-motion: reduce) {
 		.mobile-nav-container {
 			transition: none;
@@ -487,19 +571,18 @@
 		}
 
 		.mobile-nav-container.active {
-			animation: none;
+			animation: none !important;
 			transform: translateY(0);
 		}
 
-		:global(.mobile-nav-item) {
+		:global(.mobile-nav-item),
+		.mobile-nav-container.active :global(.mobile-nav-item) {
+			animation: none !important;
 			opacity: 1 !important;
 			transform: none !important;
 			transition: none !important;
+			transition-delay: 0ms !important;
 			will-change: auto;
-		}
-
-		.mobile-nav-container.active :global(.mobile-nav-item) {
-			animation: none;
 		}
 
 		:global(.mobile-nav-link),

--- a/src/styles/base/variables.css
+++ b/src/styles/base/variables.css
@@ -638,6 +638,20 @@
 	--card-glass-inset-dark: 0.06;
 	--card-glass-inset-dark-hover: 0.1;
 
+	/* ===== HEADER / NAVIGATION TOKENS =====
+	 * Dedicated opacities/blurs for the sticky header, mobile overlay and
+	 * dropdowns. Kept separate from --glass-opacity-* so headers remain
+	 * readable when they scroll over body text without affecting cards. */
+	--header-bg-opacity: 0.88;
+	--header-bg-opacity-scrolled: 0.96;
+	--header-overlay-opacity: 0.94;
+	--header-dropdown-opacity: 0.92;
+	--header-blur: var(--glass-blur-lg);
+	--header-blur-fallback: var(--glass-blur-md);
+	--header-border-opacity: 0.5;
+	--header-border-opacity-scrolled: 0.65;
+	--header-inset-opacity: 0.55;
+
 	/* Card shadow tokens */
 	--card-shadow-color: 15, 118, 110;
 	--card-shadow-opacity: 0.1;
@@ -797,6 +811,15 @@ html.dark {
 	--card-glass-border-light-hover: 0.12;
 	--card-glass-inset-light: 0.1;
 	--card-glass-inset-light-hover: 0.15;
+
+	/* Header / navigation tokens (dark) */
+	--header-bg-opacity: 0.82;
+	--header-bg-opacity-scrolled: 0.94;
+	--header-overlay-opacity: 0.94;
+	--header-dropdown-opacity: 0.92;
+	--header-border-opacity: 0.18;
+	--header-border-opacity-scrolled: 0.28;
+	--header-inset-opacity: 0.12;
 
 	/* Shadows (dark) */
 	--shadow-xs: 0 1px 2px 0 color-mix(in srgb, var(--color-black) 20%, transparent);


### PR DESCRIPTION
- Introduce dedicated --header-* opacity/blur/border tokens so the
  sticky header, mobile overlay and dropdowns stay readable over body
  text and images without borrowing the intentionally-translucent card
  glass tokens.
- Add a scrolled state on the site header that strengthens the
  background, border, and shadow once the user scrolls past the top.
- Unify backdrop blur across header, mobile overlay and dropdowns
  (--header-blur / glass-blur-lg, with saturate(180%)) and add
  @supports solid-background fallbacks.
- Normalise header inner spacing between breakpoints and give the
  logo a focus-visible ring.
- Mobile menu: trap Tab inside the panel, auto-focus the close button
  on open, restore focus to the trigger on close, Escape closes, and
  reduced-motion fully disables the item keyframes + stagger delays.
- Align dropdown item focus radius with item radius; unify mobile
  dropdown radius with the rest of the nav.
- Hamburger + mobile close button: consistent sizing, hover tint, and
  focus-visible radius.