### PR TITLE
fix(nav): seed headerScrolled state on mount

### DIFF
--- a/src/lib/components/menu/Header.svelte
+++ b/src/lib/components/menu/Header.svelte
@@ -159,6 +159,10 @@
 		window.addEventListener('resize', handleResize);
 		window.addEventListener('scroll', handleScroll, { passive: true });
 		lastScrollY = window.scrollY;
+		// Seed the scrolled state so pages opened at a non-zero scroll
+		// position (refresh with scroll restoration, deep-link hash, etc.)
+		// render with the correct header styling before any scroll event.
+		headerScrolled = window.scrollY > SCROLLED_STATE_THRESHOLD;
 
 		return () => {
 			if (dropdownTimer) {


### PR DESCRIPTION
Pages opened at a non-zero scroll position (refresh with scroll restoration or a deep-link hash) rendered with the less-readable top-of-page header styling until the first scroll event. Initialise headerScrolled alongside lastScrollY so the scrolled styling applies immediately on mount.