### PR TITLE
Actually close the reference preview when "View full details" is tapped

### DIFF
--- a/src/lib/components/reference/ItemReference.svelte
+++ b/src/lib/components/reference/ItemReference.svelte
@@ -9,6 +9,7 @@
 	 */
 
 	import { browser } from '$app/environment';
+	import { beforeNavigate } from '$app/navigation';
 	import { crossfade, fade } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
 
@@ -161,6 +162,12 @@
 		if (getActiveReferenceId() !== id && viaClick) {
 			togglePreview(false);
 		}
+	});
+
+	/* Dismiss the preview before any navigation so it never lingers
+	 * over the destination page. */
+	beforeNavigate(() => {
+		if (showPreview) togglePreview(false);
 	});
 
 	/* Re‑compute card position when preview toggles */

--- a/src/lib/components/reference/ReferencePreviewCard.svelte
+++ b/src/lib/components/reference/ReferencePreviewCard.svelte
@@ -91,15 +91,18 @@
 		if (isClicked) return;
 		isClicked = true;
 
-		// Dismiss the popover so it doesn't linger over the destination page
-		// during the click animation or after navigation completes.
-		onclose?.();
+		// Drop the .positioned class so the card plays its reverse opening
+		// animation (opacity 1→0). Without this, the wrapper's display:contents
+		// means its out:send fade has no visual effect and the card stays fully
+		// visible until the transition tears the node out of the DOM.
+		isPositioned = false;
 
-		// Delay navigation to allow animation to complete
+		// Wait for the close animation, then dismiss the parent state and navigate.
 		setTimeout(() => {
+			onclose?.();
 			// eslint-disable-next-line svelte/no-navigation-without-resolve -- itemUrl pre-resolved via resolve()
 			goto(itemUrl);
-		}, 300);
+		}, 220);
 	}
 </script>
 


### PR DESCRIPTION
The previous fix wired an onclose callback through to the parent, which
flipped showPreview to false. But the portal wrapper has display:contents,
so the out:send fade transition had no visual effect — the card sat fully
visible until Svelte tore the node out of the DOM ~200ms later, making it
look like the card never closed.

Trigger the card's own reverse opening animation by dropping .positioned
on click (opacity 1→0) and only fire onclose / goto once that animation
has played. Also dismiss the preview from beforeNavigate so it can never
linger across pages regardless of how navigation was triggered.

https://claude.ai/code/session_01MDTePwfrzzosfeP6gkwGRT