### PR TITLE
Cloudflare cache purge + CSS/a11y fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,3 +72,19 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: Purge Cloudflare cache
+        env:
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CF_ZONE_ID" ] || [ -z "$CF_API_TOKEN" ]; then
+            echo "Cloudflare secrets not configured — skipping purge."
+            exit 0
+          fi
+          curl -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}' \
+            --fail --silent --show-error
+          echo "Cloudflare cache purged."


### PR DESCRIPTION
## Summary
Three independent fixes bundled together:

1. **Cloudflare cache purge step** in the deploy workflow. Calls Cloudflare's purge API after each GitHub Pages deploy so visitors pick up new HTML and asset URLs immediately. Skips silently when \`CLOUDFLARE_ZONE_ID\` and \`CLOUDFLARE_API_TOKEN\` repo secrets aren't set.
2. **lightningcss errors** in the production build. Stripped Svelte-only \`:global()\` wrappers from the 6 plain \`.css\` files where they appeared. They're no-ops outside \`<style>\` blocks (no Svelte scoping to break out of), and lightningcss in newer Vite versions rejects them as invalid pseudo-classes, polluting the build with warnings.
3. **Mobile menu accessibility**. Replaced \`aria-hidden=\"true\"\` with the modern \`inert\` attribute on the closed mobile menu. \`aria-hidden\` doesn't remove descendants from the tab order, so the close button, theme toggle, and nav links remained focusable while hidden, which Lighthouse flags as an accessibility issue. \`inert\` removes both focus and AT exposure in one attribute.

## Context
This PR pairs with the Cloudflare Cache Rules now active in front of the site (1-year immutable for \`/app/immutable/*\`, 1-month for images/fonts, etc.). The cache purge step makes deploys propagate instantly instead of waiting for the HTML rule's edge TTL.

## Test plan
- [x] \`prettier --check\` passes for all modified files
- [x] \`npm run check\` (svelte-check) passes — 0 errors, 0 warnings
- [x] \`npm run build\` passes — no more lightningcss errors
- [x] Dev preview renders correctly in dark mode with the rewritten \`html.dark\` selectors
- [ ] After merge: confirm the \`Purge Cloudflare cache\` step in the Deploy job prints \`Cloudflare cache purged.\`