### PR TITLE
Add llms.txt and WebMCP tools for agentic browsing

### DIFF
--- a/src/lib/utils/webmcp.svelte.ts
+++ b/src/lib/utils/webmcp.svelte.ts
@@ -3,9 +3,9 @@
  *
  * Registers a small set of read-only "tools" with the browser's WebMCP runtime
  * (`navigator.modelContext`) so that AI agents browsing the site can query its
- * content reliably — searching publications, reading publication details, listing
- * research/digital-humanities projects, and fetching author/contact information —
- * instead of scraping the DOM.
+ * content reliably — searching publications and talks/events, reading their
+ * details, listing research/digital-humanities projects, and fetching
+ * author/contact information — instead of scraping the DOM.
  *
  * The API is progressively enhanced: when no WebMCP runtime is present the hook is
  * a no-op. Tools are registered when the layout mounts and unregistered on cleanup.
@@ -187,6 +187,122 @@ function buildTools(): ToolDescriptor[] {
 					tags: pub.tags,
 					url: `${SITE}/publications/${pub.id}`,
 					externalUrl: pub.url
+				});
+			}
+		},
+		{
+			name: 'search_communications',
+			description:
+				"Search Frédérick Madore's talks and events (conference papers, invited lectures, seminars, workshops, panels, and podcasts). Filter by free-text query, type, and/or year. Returns matching talks with titles, dates, venues, and URLs.",
+			inputSchema: {
+				type: 'object',
+				properties: {
+					query: {
+						type: 'string',
+						description:
+							'Free-text search matched against title, conference/venue, location, abstract, and tags.'
+					},
+					type: {
+						type: 'string',
+						description: 'Restrict to a type of talk or event.',
+						enum: ['conference', 'workshop', 'seminar', 'lecture', 'panel', 'event', 'podcast']
+					},
+					year: {
+						type: 'integer',
+						description: 'Restrict to talks from this year.'
+					},
+					limit: {
+						type: 'integer',
+						description: 'Maximum number of results to return (default 10, maximum 50).',
+						minimum: 1,
+						maximum: 50
+					}
+				},
+				required: []
+			},
+			async execute(args) {
+				const { communicationsByDate } = await import('$lib/data/communications/index');
+				const query = typeof args.query === 'string' ? args.query.toLowerCase().trim() : '';
+				const type = typeof args.type === 'string' ? args.type : '';
+				const year = typeof args.year === 'number' ? args.year : undefined;
+				const limit = Math.min(Math.max(Number(args.limit) || 10, 1), 50);
+
+				const results = communicationsByDate
+					.filter((comm) => {
+						if (type && comm.type !== type) return false;
+						if (year !== undefined && comm.year !== year) return false;
+						if (query) {
+							const haystack = [
+								comm.title,
+								comm.conference ?? '',
+								comm.location ?? '',
+								comm.abstract ?? '',
+								comm.tags?.join(' ') ?? ''
+							]
+								.join(' ')
+								.toLowerCase();
+							if (!haystack.includes(query)) return false;
+						}
+						return true;
+					})
+					.slice(0, limit)
+					.map((comm) => ({
+						id: comm.id,
+						title: comm.title,
+						type: comm.type,
+						conference: comm.conference,
+						location: comm.location,
+						country: comm.country,
+						year: comm.year,
+						url: `${SITE}/communications/${comm.id}`
+					}));
+
+				return jsonResult({ count: results.length, results });
+			}
+		},
+		{
+			name: 'get_communication_details',
+			description:
+				'Get full details for a single talk or event by its ID (as returned by search_communications). Includes the abstract, venue, panel, participants, and links.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'string',
+						description: 'The communication ID, e.g. "madore-2025-perspectives-in-motion".'
+					}
+				},
+				required: ['id']
+			},
+			async execute(args) {
+				const id = typeof args.id === 'string' ? args.id : '';
+				if (!id) return errorResult('A communication "id" is required.');
+
+				const { allCommunications } = await import('$lib/data/communications/index');
+				const comm = allCommunications.find((c) => c.id === id);
+				if (!comm) return errorResult(`No talk or event found with id "${id}".`);
+
+				return jsonResult({
+					id: comm.id,
+					title: comm.title,
+					type: comm.type,
+					authors: comm.authors,
+					year: comm.year,
+					date: comm.date,
+					conference: comm.conference,
+					panelTitle: comm.panelTitle,
+					location: comm.location,
+					country: comm.country,
+					language: comm.language,
+					abstract: comm.abstract,
+					papers: comm.papers,
+					participants: comm.participants,
+					project: comm.project,
+					tags: comm.tags,
+					doi: comm.doi,
+					url: `${SITE}/communications/${comm.id}`,
+					externalUrl: comm.url,
+					slidesUrl: comm.slidesUrl
 				});
 			}
 		},

--- a/src/lib/utils/webmcp.svelte.ts
+++ b/src/lib/utils/webmcp.svelte.ts
@@ -1,0 +1,306 @@
+/**
+ * WebMCP integration.
+ *
+ * Registers a small set of read-only "tools" with the browser's WebMCP runtime
+ * (`navigator.modelContext`) so that AI agents browsing the site can query its
+ * content reliably — searching publications, reading publication details, listing
+ * research/digital-humanities projects, and fetching author/contact information —
+ * instead of scraping the DOM.
+ *
+ * The API is progressively enhanced: when no WebMCP runtime is present the hook is
+ * a no-op. Tools are registered when the layout mounts and unregistered on cleanup.
+ *
+ * Spec: https://webmachinelearning.github.io/webmcp/ — `navigator.modelContext`.
+ */
+
+import { browser } from '$app/environment';
+import { website } from '$lib/data/siteConfig';
+
+// ---------------------------------------------------------------------------
+// Minimal typings for the (still-experimental) WebMCP API.
+// ---------------------------------------------------------------------------
+
+interface ToolContentItem {
+	type: 'text';
+	text: string;
+}
+
+interface ToolResult {
+	content: ToolContentItem[];
+	isError?: boolean;
+}
+
+interface ToolDescriptor {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	execute: (args: Record<string, unknown>) => Promise<ToolResult> | ToolResult;
+}
+
+interface ToolRegistration {
+	unregister?: () => void;
+}
+
+interface ModelContext {
+	registerTool?: (tool: ToolDescriptor) => ToolRegistration | undefined;
+}
+
+const SITE = website.url;
+
+/** Wrap a JSON-serialisable value as a WebMCP text result. */
+function jsonResult(value: unknown): ToolResult {
+	return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+/** Wrap an error message as a WebMCP error result. */
+function errorResult(message: string): ToolResult {
+	return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions.
+//
+// Data modules are imported lazily inside `execute` so they stay out of the
+// initial bundle and are only loaded when an agent actually calls a tool.
+// ---------------------------------------------------------------------------
+
+function buildTools(): ToolDescriptor[] {
+	return [
+		{
+			name: 'search_publications',
+			description:
+				"Search Frédérick Madore's academic publications (books, journal articles, book chapters, edited volumes, reports, and encyclopedia entries). Filter by free-text query, publication type, and/or year. Returns matching publications with titles, years, types, authors, and URLs.",
+			inputSchema: {
+				type: 'object',
+				properties: {
+					query: {
+						type: 'string',
+						description: 'Free-text search matched against title, authors, abstract, and tags.'
+					},
+					type: {
+						type: 'string',
+						description: 'Restrict to a publication type.',
+						enum: [
+							'book',
+							'article',
+							'chapter',
+							'special-issue',
+							'report',
+							'encyclopedia',
+							'blogpost',
+							'phd-dissertation',
+							'masters-thesis',
+							'conference-proceedings',
+							'bulletin-article'
+						]
+					},
+					year: {
+						type: 'integer',
+						description: 'Restrict to publications from this year.'
+					},
+					limit: {
+						type: 'integer',
+						description: 'Maximum number of results to return (default 10, maximum 50).',
+						minimum: 1,
+						maximum: 50
+					}
+				},
+				required: []
+			},
+			async execute(args) {
+				const { publicationsByDate } = await import('$lib/data/publications/index');
+				const query = typeof args.query === 'string' ? args.query.toLowerCase().trim() : '';
+				const type = typeof args.type === 'string' ? args.type : '';
+				const year = typeof args.year === 'number' ? args.year : undefined;
+				const limit = Math.min(Math.max(Number(args.limit) || 10, 1), 50);
+
+				const results = publicationsByDate
+					.filter((pub) => {
+						if (type && pub.type !== type) return false;
+						if (year !== undefined && pub.year !== year) return false;
+						if (query) {
+							const haystack = [
+								pub.title,
+								pub.authors?.join(' '),
+								pub.abstract ?? '',
+								pub.tags?.join(' ') ?? ''
+							]
+								.join(' ')
+								.toLowerCase();
+							if (!haystack.includes(query)) return false;
+						}
+						return true;
+					})
+					.slice(0, limit)
+					.map((pub) => ({
+						id: pub.id,
+						title: pub.title,
+						type: pub.type,
+						year: pub.year,
+						authors: pub.authors,
+						url: `${SITE}/publications/${pub.id}`,
+						doi: pub.doi
+					}));
+
+				return jsonResult({ count: results.length, results });
+			}
+		},
+		{
+			name: 'get_publication_details',
+			description:
+				'Get full details for a single publication by its ID (as returned by search_publications). Includes the abstract, citation metadata, and links.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'string',
+						description: 'The publication ID, e.g. "religious-activism-campuses".'
+					}
+				},
+				required: ['id']
+			},
+			async execute(args) {
+				const id = typeof args.id === 'string' ? args.id : '';
+				if (!id) return errorResult('A publication "id" is required.');
+
+				const { allPublications } = await import('$lib/data/publications/index');
+				const pub = allPublications.find((p) => p.id === id);
+				if (!pub) return errorResult(`No publication found with id "${id}".`);
+
+				return jsonResult({
+					id: pub.id,
+					title: pub.title,
+					type: pub.type,
+					authors: pub.authors,
+					year: pub.year,
+					date: pub.date,
+					language: pub.language,
+					publisher: pub.publisher,
+					journal: pub.journal,
+					book: pub.book,
+					volume: pub.volume,
+					issue: pub.issue,
+					pages: pub.pages,
+					doi: pub.doi,
+					isbn: pub.isbn,
+					abstract: pub.abstract,
+					tags: pub.tags,
+					url: `${SITE}/publications/${pub.id}`,
+					externalUrl: pub.url
+				});
+			}
+		},
+		{
+			name: 'list_research_projects',
+			description:
+				"List Frédérick Madore's research projects and digital humanities projects, with short descriptions and URLs.",
+			inputSchema: {
+				type: 'object',
+				properties: {},
+				required: []
+			},
+			async execute() {
+				const { allDhProjects } = await import('$lib/data/digital-humanities');
+				const research = [
+					{
+						id: 'islams-peripheries-dh-ai-west-africa-central-asia',
+						title:
+							"Islam's 'Peripheries': Digital Humanities, Algorithmic Analysis, and AI in West Africa and Central Asia"
+					},
+					{
+						id: 'dh-ai-african-studies',
+						title: 'Digital Humanities and Artificial Intelligence in African Studies'
+					},
+					{
+						id: 'religious-activism-campuses-togo-benin',
+						title: 'Religious Activism on Campuses in Togo and Benin'
+					},
+					{
+						id: 'muslim-minorities-southern-cities-benin-togo',
+						title: 'Muslim Minorities in Southern Cities of Benin and Togo'
+					},
+					{
+						id: 'youth-womens-islamic-activism-cote-divoire-burkina-faso',
+						title: "Youth and Women's Islamic Activism in Côte d'Ivoire and Burkina Faso"
+					}
+				].map((p) => ({ ...p, url: `${SITE}/research/${p.id}` }));
+
+				const digitalHumanities = allDhProjects.map((p) => ({
+					id: p.id,
+					title: p.title,
+					shortDescription: p.shortDescription,
+					url: `${SITE}/digital-humanities/${p.id}`
+				}));
+
+				return jsonResult({ research, digitalHumanities });
+			}
+		},
+		{
+			name: 'get_author_info',
+			description:
+				'Get information about the site owner, Frédérick Madore: name, academic position, affiliation, contact email, and scholarly/social profile links.',
+			inputSchema: {
+				type: 'object',
+				properties: {},
+				required: []
+			},
+			async execute() {
+				const { author, address, contact, socialLinks } = await import('$lib/data/siteConfig');
+				return jsonResult({
+					name: author.name,
+					fullName: author.fullName,
+					position: author.position,
+					affiliation: {
+						institution: address.institution,
+						department: address.department,
+						city: address.city,
+						country: address.country
+					},
+					email: contact.email,
+					website: SITE,
+					profiles: {
+						orcid: socialLinks.orcid.url,
+						googleScholar: socialLinks.googleScholar.url,
+						researchGate: socialLinks.researchGate.url,
+						github: socialLinks.github.url,
+						linkedIn: socialLinks.linkedIn.url,
+						bluesky: socialLinks.bluesky.url
+					}
+				});
+			}
+		}
+	];
+}
+
+/**
+ * Registers WebMCP tools for the current document.
+ * Must be called at component top-level (uses $effect).
+ */
+export function useWebMcp(): void {
+	$effect(() => {
+		if (!browser) return;
+
+		const modelContext = (navigator as Navigator & { modelContext?: ModelContext }).modelContext;
+		if (!modelContext || typeof modelContext.registerTool !== 'function') return;
+
+		const registrations: ToolRegistration[] = [];
+		for (const tool of buildTools()) {
+			try {
+				const registration = modelContext.registerTool(tool);
+				if (registration) registrations.push(registration);
+			} catch (err) {
+				if (import.meta.env.DEV) console.error('[WebMCP] Failed to register tool:', tool.name, err);
+			}
+		}
+
+		return () => {
+			for (const registration of registrations) {
+				try {
+					registration.unregister?.();
+				} catch {
+					// Ignore cleanup failures — the document is going away anyway.
+				}
+			}
+		};
+	});
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,6 +20,7 @@
 	import { useGtm } from '$lib/utils/gtm.svelte';
 	import { useNetworkMonitor } from '$lib/utils/networkMonitor.svelte';
 	import { useJsonLdScript } from '$lib/utils/jsonLd.svelte';
+	import { useWebMcp } from '$lib/utils/webmcp.svelte';
 
 	// Register all icons at app startup to avoid API calls
 	registerIcons();
@@ -36,6 +37,9 @@
 
 	// Monitor network status
 	useNetworkMonitor();
+
+	// Register WebMCP tools so AI agents can query the site reliably
+	useWebMcp();
 
 	// Initialize performance monitoring
 	$effect(() => {

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { author, website, contact, address, socialLinks } from '$lib/data/siteConfig';
 import { publicationsByDate } from '$lib/data/publications/index';
+import { communicationsByDate } from '$lib/data/communications/index';
 import { allDhProjects } from '$lib/data/digital-humanities';
 
 // Prerender as a static text file for the agentic-browsing / llms.txt convention.
@@ -53,6 +54,7 @@ const oneLine = (value: string): string => value.replace(/\s+/g, ' ').trim();
 
 export const GET: RequestHandler = async () => {
 	const recentPublications = publicationsByDate.slice(0, 20);
+	const recentCommunications = communicationsByDate.slice(0, 15);
 
 	const lines: string[] = [];
 
@@ -95,7 +97,7 @@ export const GET: RequestHandler = async () => {
 		`- [Activities](${SITE}/activities): News, talks, workshops, and other scholarly activities.`
 	);
 	lines.push(
-		`- [Conference activity](${SITE}/conference-activity): Conference papers, panels, and presentation slides.`
+		`- [Talks & Events](${SITE}/conference-activity): Conference papers, invited lectures, seminars, workshops, panels, podcasts, and presentation slides.`
 	);
 	lines.push(`- [Teaching](${SITE}/teaching): Courses, guest lectures, and syllabi.`);
 	lines.push(`- [CV](${SITE}/cv): Full curriculum vitae.`);
@@ -124,6 +126,18 @@ export const GET: RequestHandler = async () => {
 	for (const pub of recentPublications) {
 		lines.push(
 			`- [${oneLine(pub.title)}](${SITE}/publications/${pub.id}) (${pub.year}) — ${pub.type}`
+		);
+	}
+	lines.push('');
+
+	// Selected recent talks & events.
+	lines.push('## Selected recent talks & events');
+	lines.push('');
+	for (const comm of recentCommunications) {
+		const venue = [comm.conference, comm.location].filter(Boolean).join(', ');
+		const suffix = venue ? ` — ${oneLine(venue)}` : '';
+		lines.push(
+			`- [${oneLine(comm.title)}](${SITE}/communications/${comm.id}) (${comm.year})${suffix}`
 		);
 	}
 	lines.push('');

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,0 +1,162 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { author, website, contact, address, socialLinks } from '$lib/data/siteConfig';
+import { publicationsByDate } from '$lib/data/publications/index';
+import { allDhProjects } from '$lib/data/digital-humanities';
+
+// Prerender as a static text file for the agentic-browsing / llms.txt convention.
+export const prerender = true;
+
+/**
+ * /llms.txt endpoint
+ *
+ * Implements the llms.txt convention (https://llmstxt.org/): a Markdown file that
+ * gives large language models and AI agents a curated, machine-readable map of the
+ * site. The file is generated from the same data sources as the rest of the site so
+ * it never drifts out of sync.
+ *
+ * Structure follows the spec:
+ *   - a single H1 with the site/project name (required)
+ *   - a blockquote one-line summary
+ *   - optional free-text context
+ *   - H2 sections containing curated lists of links
+ */
+
+const SITE = website.url;
+
+/** Curated research projects (mirrors the Research landing page). */
+const researchProjects: Array<{ id: string; title: string }> = [
+	{
+		id: 'islams-peripheries-dh-ai-west-africa-central-asia',
+		title:
+			"Islam's 'Peripheries': Digital Humanities, Algorithmic Analysis, and AI in West Africa and Central Asia"
+	},
+	{
+		id: 'dh-ai-african-studies',
+		title: 'Digital Humanities and Artificial Intelligence in African Studies'
+	},
+	{
+		id: 'religious-activism-campuses-togo-benin',
+		title: 'Religious Activism on Campuses in Togo and Benin'
+	},
+	{
+		id: 'muslim-minorities-southern-cities-benin-togo',
+		title: 'Muslim Minorities in Southern Cities of Benin and Togo'
+	},
+	{
+		id: 'youth-womens-islamic-activism-cote-divoire-burkina-faso',
+		title: "Youth and Women's Islamic Activism in Côte d'Ivoire and Burkina Faso"
+	}
+];
+
+/** Collapse whitespace so multi-line source strings render as single Markdown lines. */
+const oneLine = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+export const GET: RequestHandler = async () => {
+	const recentPublications = publicationsByDate.slice(0, 20);
+
+	const lines: string[] = [];
+
+	// Required H1 + blockquote summary.
+	lines.push(`# ${author.name}`);
+	lines.push('');
+	lines.push(
+		`> ${author.fullName} is a historian of Islam in francophone West Africa and a digital humanities specialist working as Data Curator at the "Africa Multiple" Cluster of Excellence, University of Bayreuth. This is his academic website, collecting his publications, conference activity, teaching, and digital humanities projects.`
+	);
+	lines.push('');
+	lines.push(
+		oneLine(`Frédérick Madore combines archival and field research with digital humanities and
+		AI-enhanced computational pipelines to study Islam in francophone West Africa (notably Benin,
+		Burkina Faso, Côte d'Ivoire, and Togo). His work covers Muslim activism on university campuses,
+		Muslim minorities, religious authority, and the building of digital archives and tools for
+		African studies.`)
+	);
+	lines.push('');
+	lines.push(
+		oneLine(`This file follows the llms.txt convention (https://llmstxt.org/) to help AI agents and
+		large language models discover the most relevant pages. All URLs are absolute and resolve to
+		the live site. Structured data (JSON-LD), an RSS feed, and an XML sitemap are also available.`)
+	);
+	lines.push('');
+
+	// Key pages.
+	lines.push('## Key pages');
+	lines.push('');
+	lines.push(`- [Home](${SITE}/): Overview, current position, and latest activity.`);
+	lines.push(
+		`- [Publications](${SITE}/publications): Complete, filterable list of books, journal articles, book chapters, edited volumes, reports, and encyclopedia entries, with citation export (BibTeX, APA, MLA, Chicago).`
+	);
+	lines.push(
+		`- [Research](${SITE}/research): Current and past research projects on Islam in West Africa and digital humanities.`
+	);
+	lines.push(
+		`- [Digital Humanities](${SITE}/digital-humanities): Digital archives, datasets, and AI tools, including the Islam West Africa Collection (IWAC).`
+	);
+	lines.push(
+		`- [Activities](${SITE}/activities): News, talks, workshops, and other scholarly activities.`
+	);
+	lines.push(
+		`- [Conference activity](${SITE}/conference-activity): Conference papers, panels, and presentation slides.`
+	);
+	lines.push(`- [Teaching](${SITE}/teaching): Courses, guest lectures, and syllabi.`);
+	lines.push(`- [CV](${SITE}/cv): Full curriculum vitae.`);
+	lines.push('');
+
+	// Research projects.
+	lines.push('## Research projects');
+	lines.push('');
+	for (const project of researchProjects) {
+		lines.push(`- [${project.title}](${SITE}/research/${project.id})`);
+	}
+	lines.push('');
+
+	// Digital humanities projects.
+	lines.push('## Digital humanities projects');
+	lines.push('');
+	for (const project of allDhProjects) {
+		const summary = project.shortDescription ? `: ${oneLine(project.shortDescription)}` : '';
+		lines.push(`- [${project.title}](${SITE}/digital-humanities/${project.id})${summary}`);
+	}
+	lines.push('');
+
+	// Selected recent publications.
+	lines.push('## Selected recent publications');
+	lines.push('');
+	for (const pub of recentPublications) {
+		lines.push(
+			`- [${oneLine(pub.title)}](${SITE}/publications/${pub.id}) (${pub.year}) — ${pub.type}`
+		);
+	}
+	lines.push('');
+
+	// Feeds and machine-readable data.
+	lines.push('## Feeds and data');
+	lines.push('');
+	lines.push(`- [RSS feed](${SITE}/rss.xml): Latest activities and updates.`);
+	lines.push(`- [XML sitemap](${SITE}/sitemap.xml): Full list of indexable pages.`);
+	lines.push('');
+
+	// Contact and scholarly profiles.
+	lines.push('## Contact and profiles');
+	lines.push('');
+	lines.push(`- Email: ${contact.email}`);
+	lines.push(
+		`- Affiliation: ${address.institution} (${address.department}), ${address.city}, ${address.country}`
+	);
+	lines.push(`- [ORCID](${socialLinks.orcid.url})`);
+	lines.push(`- [Google Scholar](${socialLinks.googleScholar.url})`);
+	lines.push(`- [ResearchGate](${socialLinks.researchGate.url})`);
+	lines.push(`- [GitHub](${socialLinks.github.url})`);
+	lines.push(`- [LinkedIn](${socialLinks.linkedIn.url})`);
+	lines.push(`- [Bluesky](${socialLinks.bluesky.url})`);
+	lines.push('');
+
+	const body = lines.join('\n');
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+			'Cache-Control': 'max-age=3600, s-maxage=3600',
+			'X-Content-Type-Options': 'nosniff'
+		}
+	});
+};

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -5,3 +5,6 @@ Sitemap: https://www.frederickmadore.com/sitemap.xml
 
 # RSS Feed available at: https://www.frederickmadore.com/rss.xml
 # (Discovered via <link rel="alternate" type="application/rss+xml"> in HTML)
+
+# LLM/AI agent guidance: https://www.frederickmadore.com/llms.txt
+# (Curated, machine-readable site map following the llms.txt convention)


### PR DESCRIPTION
Implements the AI-readiness audits surfaced by PageSpeed Insights /
Lighthouse "Agentic Browsing":

- /llms.txt endpoint (prerendered) following the llmstxt.org convention:
  required H1 + blockquote summary, curated link sections for key pages,
  research and digital-humanities projects, recent publications, feeds,
  and contact/profile links. Generated from existing data so it stays in
  sync. robots.txt now points agents to it.

- WebMCP integration via navigator.modelContext.registerTool, registering
  four read-only tools (search_publications, get_publication_details,
  list_research_projects, get_author_info) with valid JSON Schemas so AI
  agents can query the site instead of scraping the DOM. Progressively
  enhanced (no-op without a WebMCP runtime); tools register on layout
  mount and unregister on cleanup. Data modules are lazy-imported.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Pbh2nV65mNXqS89U7A4RM